### PR TITLE
Implement string reverse method

### DIFF
--- a/src/builtin.rs
+++ b/src/builtin.rs
@@ -1121,6 +1121,9 @@ impl Engine<'_> {
             s.clear();
             s.push_str(&new_str);
         });
+        self.register_fn("reverse", |s: &mut String| {
+            s.chars().rev().collect::<String>()
+        });
         self.register_fn("trim", |s: &mut String| {
             let trimmed = s.trim();
 

--- a/tests/string.rs
+++ b/tests/string.rs
@@ -140,3 +140,23 @@ fn test_string_substring() -> Result<(), EvalAltResult> {
 
     Ok(())
 }
+
+#[test]
+fn test_reverse() -> Result<(), EvalAltResult> {
+    let engine = Engine::new();
+
+    assert_eq!(
+        engine.eval::<String>(
+            r#"let x = "\u2764\u2764"; x.reverse()"#
+        )?,
+        "❤❤"
+    );
+    assert_eq!(
+        engine.eval::<String>(
+            r#"let x = "\u2764\u2764\u2764 hello!"; x.reverse()"#
+        )?,
+        "!olleh ❤❤❤"
+    );
+
+    Ok(())
+}


### PR DESCRIPTION
Based on your usual practice, and previous comments, here is a `reverse` method on strings.

I presume it will be easier to get it merged as-is with my authorship here, rather than upstream where you would have to pull it back down again.