### PR TITLE
Added basic Plugin trait and test

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,6 +22,7 @@ num-traits = { version = "0.2.11", default-features = false }
 [features]
 #default = ["no_stdlib", "no_function", "no_index", "no_object", "no_float", "only_i32", "unchecked", "no_optimize", "sync"]
 default = []
+plugins = []
 unchecked = []      # unchecked arithmetic
 no_index = []       # no arrays and indexing
 no_float = []       # no floating-point

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -89,6 +89,8 @@ pub use engine::{calc_fn_spec as calc_fn_hash, Engine};
 pub use error::{ParseError, ParseErrorType};
 pub use fn_call::FuncArgs;
 pub use fn_register::{RegisterDynamicFn, RegisterFn, RegisterResultFn};
+#[cfg(feature = "plugins")]
+pub use fn_register::{Plugin, RegisterPlugin};
 pub use parser::{AST, INT};
 pub use result::EvalAltResult;
 pub use scope::Scope;


### PR DESCRIPTION
This is the foundation for my approach described in #3. Once this gets merged, I will be able to continue my work on procedural macro plugins.

I have a test of the API I added. This test generates the code by hand. Its `register_contents` function will not be the way going forward, it is just to make the API testable.