### PR TITLE
Fix method behavior

### DIFF
--- a/src/engine.rs
+++ b/src/engine.rs
@@ -807,13 +807,16 @@ impl Engine {
             match rhs {
                 // xxx.fn_name(arg_expr_list)
                 Expr::FnCall(fn_name, _, def_val, pos) => {
+                    // TODO: Fix this in parser
+                    assert!(new_val.is_none());
+
                     let mut args: Vec<_> = once(obj)
                         .chain(idx_val.downcast_mut::<Array>().unwrap().iter_mut())
                         .collect();
                     let def_val = def_val.as_deref();
                     // A function call is assumed to have side effects, so the value is changed
                     // TODO - Remove assumption of side effects by checking whether the first parameter is &mut
-                    self.exec_fn_call(fn_lib, fn_name, &mut args, def_val, *pos, 0).map(|v| (v, true))
+                    self.exec_fn_call(fn_lib, fn_name, &mut args, def_val, *pos, 0).map(|v| (v, false))
                 }
                 // {xxx:map}.id = ???
                 Expr::Property(id, pos) if obj.is::<Map>() && new_val.is_some() => {


### PR DESCRIPTION
Methods currently don't do what I would expect. This fixes two issues, though in one case hackily (and in a way that should be fixed for #102).

The first issue, fixed hackily, is that `a.b() = foo` just throws away the value of foo. This is pretty unexpected behavior. It should really be fixed at the parser level giving an error if that syntax is used.

The second issue, fixed properly, is that methods claim to be propagating a value upwards that should be set. Typically this value (if propagated) should be something like a `Map` returning a modified version of itself. Instead the method is propagating the value it was evaluated to up. This results in some pretty unexpected behavior.

To see how problematic the second issue is - try and predict the output of [this program](https://gist.github.com/gmorenz/ef788227a55a113942020694d7d1e2ed) without this change.