### PR TITLE
Companion code to get_mut proposal

### DIFF
--- a/src/any.rs
+++ b/src/any.rs
@@ -47,6 +47,9 @@ pub trait Variant: Any {
     /// Clone into `Dynamic`.
     fn clone_into_dynamic(&self) -> Dynamic;
 
+    // Try to move ourselves into other
+    fn try_write(self: Box<Self>, other: &mut dyn Variant) -> bool;
+
     /// This trait may only be implemented by `rhai`.
     #[doc(hidden)]
     fn _closed(&self) -> _Private;
@@ -68,6 +71,15 @@ impl<T: Any + Clone> Variant for T {
     }
     fn clone_into_dynamic(&self) -> Dynamic {
         Dynamic::from(self.clone())
+    }
+    fn try_write(self: Box<Self>, other: &mut dyn Variant) -> bool {
+        if let Some(place) = other.downcast_mut::<Self>() {
+            *place = *self;
+            true
+        }
+        else {
+            false
+        }
     }
     fn _closed(&self) -> _Private {
         _Private
@@ -95,6 +107,9 @@ pub trait Variant: Any + Send + Sync {
     /// Clone into `Dynamic`.
     fn clone_into_dynamic(&self) -> Dynamic;
 
+    // Try to move ourselves into other
+    fn try_write(self: Box<Self>, other: &mut Variant) -> bool;
+
     /// This trait may only be implemented by `rhai`.
     #[doc(hidden)]
     fn _closed(&self) -> _Private;
@@ -116,6 +131,15 @@ impl<T: Any + Clone + Send + Sync> Variant for T {
     }
     fn clone_into_dynamic(&self) -> Dynamic {
         Dynamic::from(self.clone())
+    }
+    fn try_write(self: Box<Self>, other: &mut Variant) -> bool {
+        if let Some(place) = other.downcast_mut::<Self>() {
+            *place = *self;
+            true
+        }
+        else {
+            false
+        }
     }
     fn _closed(&self) -> _Private {
         _Private

--- a/src/any.rs
+++ b/src/any.rs
@@ -151,6 +151,18 @@ impl dyn Variant {
     pub fn is<T: Any>(&self) -> bool {
         TypeId::of::<T>() == self.type_id()
     }
+
+    /// Get a reference of a specific type to the `Variant`.
+    /// Returns `None` if the cast fails.
+    pub fn downcast_ref<T: Any>(&self) -> Option<&T> {
+        Any::downcast_ref::<T>(self.as_any())
+    }
+
+    /// Get a mutable reference of a specific type to the `Variant`.
+    /// Returns `None` if the cast fails.
+    pub fn downcast_mut<T: Any>(&mut self) -> Option<&mut T> {
+        Any::downcast_mut::<T>(self.as_mut_any())
+    }
 }
 
 /// A dynamic type containing any value.

--- a/src/any.rs
+++ b/src/any.rs
@@ -491,7 +491,7 @@ impl Dynamic {
     /// Get a reference of a specific type to the `Dynamic`.
     /// Casting to `Dynamic` just returns a reference to it.
     /// Returns `None` if the cast fails.
-    pub fn downcast_ref<T: Variant + Clone>(&self) -> Option<&T> {
+    pub fn downcast_ref<T: Variant>(&self) -> Option<&T> {
         if TypeId::of::<T>() == TypeId::of::<Dynamic>() {
             return (self as &dyn Any).downcast_ref::<T>();
         }
@@ -517,7 +517,7 @@ impl Dynamic {
     /// Get a mutable reference of a specific type to the `Dynamic`.
     /// Casting to `Dynamic` just returns a mutable reference to it.
     /// Returns `None` if the cast fails.
-    pub fn downcast_mut<T: Variant + Clone>(&mut self) -> Option<&mut T> {
+    pub fn downcast_mut<T: Variant>(&mut self) -> Option<&mut T> {
         if TypeId::of::<T>() == TypeId::of::<Dynamic>() {
             return (self as &mut dyn Any).downcast_mut::<T>();
         }

--- a/src/any.rs
+++ b/src/any.rs
@@ -21,6 +21,8 @@ use crate::stdlib::{
     fmt,
     string::String,
     vec::Vec,
+    mem,
+    ptr,
 };
 
 #[cfg(not(feature = "no_std"))]
@@ -37,6 +39,9 @@ pub trait Variant: Any {
 
     /// Convert this `Variant` trait object to `&mut dyn Any`.
     fn as_mut_any(&mut self) -> &mut dyn Any;
+
+    /// Convert this `Variant` trait object to `Box<Any>`
+    fn as_box_any(self: Box<Self>) -> Box<Any>;
 
     /// Get the name of this type.
     fn type_name(&self) -> &'static str;
@@ -62,6 +67,9 @@ impl<T: Any + Clone> Variant for T {
     }
     fn as_mut_any(&mut self) -> &mut dyn Any {
         self as &mut dyn Any
+    }
+    fn as_box_any(self: Box<Self>) -> Box<Any> {
+        self as Box<Any>
     }
     fn type_name(&self) -> &'static str {
         type_name::<T>()
@@ -98,6 +106,9 @@ pub trait Variant: Any + Send + Sync {
     /// Convert this `Variant` trait object to `&mut dyn Any`.
     fn as_mut_any(&mut self) -> &mut dyn Any;
 
+    /// Convert this `Variant` trait object to `Box<Any>`
+    fn as_box_any(self: Box<Self>) -> Box<Any>;
+
     /// Get the name of this type.
     fn type_name(&self) -> &'static str;
 
@@ -122,6 +133,9 @@ impl<T: Any + Clone + Send + Sync> Variant for T {
     }
     fn as_mut_any(&mut self) -> &mut dyn Any {
         self as &mut dyn Any
+    }
+    fn as_box_any(self: Box<Self>) -> Box<Any> {
+        self as Box<Any>
     }
     fn type_name(&self) -> &'static str {
         type_name::<T>()
@@ -320,6 +334,23 @@ impl Default for Dynamic {
     }
 }
 
+// Why is this not built in? I have no clue
+fn try_cast<A: Any, B: Any>(a: A) -> Option<B> {
+    if TypeId::of::<B>() == a.type_id() {
+        // SAFETY: Just checked we have the right type. We explicitly forget the
+        // value immediately after moving out, removing any chance of a destructor
+        // running or value otherwise being used again.
+        unsafe {
+            let ret: B = ptr::read(&a as *const _ as *const B);
+            mem::forget(a);
+            Some(ret)
+        }
+    }
+    else {
+        None
+    }
+} 
+
 /// Cast a Boxed type into another type.
 fn cast_box<X: Variant, T: Variant>(item: Box<X>) -> Result<Box<T>, Box<X>> {
     // Only allow casting to the exact same type
@@ -424,26 +455,35 @@ impl Dynamic {
     ///
     /// assert_eq!(x.try_cast::<u32>().unwrap(), 42);
     /// ```
-    pub fn try_cast<T: Variant + Clone>(self) -> Option<T> {
+    pub fn try_cast<T: Variant>(self) -> Option<T> {
+        // TODO: Potentially support casting to boxed variants as well...
+
         if TypeId::of::<T>() == TypeId::of::<Dynamic>() {
             return cast_box::<_, T>(Box::new(self)).ok().map(|v| *v);
         }
 
         match self.0 {
-            Union::Unit(ref value) => (value as &dyn Any).downcast_ref::<T>().cloned(),
-            Union::Bool(ref value) => (value as &dyn Any).downcast_ref::<T>().cloned(),
-            Union::Str(value) => cast_box::<_, T>(value).ok().map(|v| *v),
-            Union::Char(ref value) => (value as &dyn Any).downcast_ref::<T>().cloned(),
-            Union::Int(ref value) => (value as &dyn Any).downcast_ref::<T>().cloned(),
+            Union::Unit(value) => try_cast(value),
+            Union::Bool(value) => try_cast(value),
+            Union::Char(value) => try_cast(value),
+            Union::Int(value) => try_cast(value),
             #[cfg(not(feature = "no_float"))]
-            Union::Float(ref value) => (value as &dyn Any).downcast_ref::<T>().cloned(),
+            Union::Float(value) => try_cast(value),
+
+            Union::Variant(value) => {
+                let b1: Box<dyn Variant> = *value;
+                let b2: Box<dyn Any> = b1.as_box_any();
+                let b3: Result<Box<T>, _> = b2.downcast();
+                b3.map(|x| Some(*x)).unwrap_or(None)
+            }
+            
+            Union::Str(value) => cast_box::<_, T>(value).ok().map(|v| *v),
             #[cfg(not(feature = "no_index"))]
             Union::Array(value) => cast_box::<_, T>(value).ok().map(|v| *v),
             #[cfg(not(feature = "no_object"))]
             Union::Map(value) => cast_box::<_, T>(value).ok().map(|v| *v),
             #[cfg(not(feature = "no_module"))]
             Union::Module(value) => cast_box::<_, T>(value).ok().map(|v| *v),
-            Union::Variant(value) => value.as_any().downcast_ref::<T>().cloned(),
         }
     }
 

--- a/src/api.rs
+++ b/src/api.rs
@@ -1,7 +1,7 @@
 //! Module that defines the extern API of `Engine`.
 
 use crate::any::{Dynamic, Variant};
-use crate::engine::{make_getter, make_setter, Engine, State, FUNC_INDEXER};
+use crate::engine::{make_getter,make_mut_getter, make_setter, Engine, State, FUNC_INDEXER};
 use crate::error::ParseError;
 use crate::fn_call::FuncArgs;
 use crate::fn_register::RegisterFn;
@@ -35,6 +35,16 @@ impl<F: Fn(&mut T) -> U + Send + Sync + 'static, T, U> ObjectGetCallback<T, U> f
 pub trait ObjectGetCallback<T, U>: Fn(&mut T) -> U + 'static {}
 #[cfg(not(feature = "sync"))]
 impl<F: Fn(&mut T) -> U + 'static, T, U> ObjectGetCallback<T, U> for F {}
+
+#[cfg(feature = "sync")]
+pub trait ObjectGetMutCallback<T, U>: Fn(&mut T) -> &mut U + Send + Sync + 'static {}
+#[cfg(feature = "sync")]
+impl<F: Fn(&mut T) -> &mut U + Send + Sync + 'static, T, U> ObjectGetMutCallback<T, U> for F {}
+
+#[cfg(not(feature = "sync"))]
+pub trait ObjectGetMutCallback<T, U>: Fn(&mut T) -> &mut U + 'static {}
+#[cfg(not(feature = "sync"))]
+impl<F: Fn(&mut T) -> &mut U + 'static, T, U> ObjectGetMutCallback<T, U> for F {}
 
 #[cfg(feature = "sync")]
 pub trait ObjectSetCallback<T, U>: Fn(&mut T, U) + Send + Sync + 'static {}

--- a/src/api.rs
+++ b/src/api.rs
@@ -57,14 +57,14 @@ pub trait ObjectSetCallback<T, U>: Fn(&mut T, U) + 'static {}
 impl<F: Fn(&mut T, U) + 'static, T, U> ObjectSetCallback<T, U> for F {}
 
 #[cfg(feature = "sync")]
-pub trait ObjectIndexerCallback<T, X, U>: Fn(&mut T, X) -> U + Send + Sync + 'static {}
+pub trait ObjectMutIndexerCallback<T, X, U>: Fn(&'a mut T, X) -> &'a mut U + Send + Sync + 'static {}
 #[cfg(feature = "sync")]
-impl<F: Fn(&mut T, X) -> U + Send + Sync + 'static, T, X, U> ObjectIndexerCallback<T, X, U> for F {}
+impl<F: Fn(&mut T, X) -> &mut U + Send + Sync + 'static, T, X, U> ObjectMutIndexerCallback<T, X, U> for F {}
 
 #[cfg(not(feature = "sync"))]
-pub trait ObjectIndexerCallback<T, X, U>: Fn(&mut T, X) -> U + 'static {}
+pub trait ObjectMutIndexerCallback<T, X, U>: for<'a> Fn(&'a mut T, X) -> &'a mut U + 'static {}
 #[cfg(not(feature = "sync"))]
-impl<F: Fn(&mut T, X) -> U + 'static, T, X, U> ObjectIndexerCallback<T, X, U> for F {}
+impl<F: Fn(&mut T, X) -> &mut U + 'static, T, X, U> ObjectMutIndexerCallback<T, X, U> for F {}
 
 #[cfg(feature = "sync")]
 pub trait IteratorCallback:
@@ -321,54 +321,6 @@ impl Engine {
     {
         self.register_get(name, get_fn);
         self.register_set(name, set_fn);
-    }
-
-    /// Register an indexer function for a registered type with the `Engine`.
-    ///
-    /// The function signature must start with `&mut self` and not `&self`.
-    ///
-    /// # Example
-    ///
-    /// ```
-    /// #[derive(Clone)]
-    /// struct TestStruct {
-    ///     fields: Vec<i64>
-    /// }
-    ///
-    /// impl TestStruct {
-    ///     fn new() -> Self                { TestStruct { fields: vec![1, 2, 3, 4, 5] } }
-    ///
-    ///     // Even a getter must start with `&mut self` and not `&self`.
-    ///     fn get_field(&mut self, index: i64) -> i64 { self.fields[index as usize] }
-    /// }
-    ///
-    /// # fn main() -> Result<(), Box<rhai::EvalAltResult>> {
-    /// use rhai::{Engine, RegisterFn};
-    ///
-    /// let mut engine = Engine::new();
-    ///
-    /// // Register the custom type.
-    /// engine.register_type::<TestStruct>();
-    ///
-    /// engine.register_fn("new_ts", TestStruct::new);
-    ///
-    /// // Register an indexer.
-    /// engine.register_indexer(TestStruct::get_field);
-    ///
-    /// assert_eq!(engine.eval::<i64>("let a = new_ts(); a[2]")?, 3);
-    /// # Ok(())
-    /// # }
-    /// ```
-    #[cfg(not(feature = "no_object"))]
-    #[cfg(not(feature = "no_index"))]
-    pub fn register_indexer<T, X, U, F>(&mut self, callback: F)
-    where
-        T: Variant + Clone,
-        U: Variant + Clone,
-        X: Variant + Clone,
-        F: ObjectIndexerCallback<T, X, U>,
-    {
-        self.register_fn(FUNC_INDEXER, callback);
     }
 
     /// Compile a string into an `AST`, which can be used later for evaluation.

--- a/src/engine.rs
+++ b/src/engine.rs
@@ -115,9 +115,13 @@ impl Engine {
         let fn_name = make_mut_getter(name);
         let hash = calc_fn_hash(&fn_name, std::iter::once(TypeId::of::<T>()));
 
-        let function = Function::new(callback);
+        let function = Function::new(callback.clone());
         let dny_any_callback: Box<dyn ObjectGetMutCallbackAny> = Box::new(function) as Box<dyn ObjectGetMutCallbackAny>; 
         self.mut_getters.insert(hash, dny_any_callback);
+
+        let callback_1 = callback.clone();
+        self.register_get(name, move |arg: &mut T| callback_1(arg).clone());
+        self.register_set(name, move |arg: &mut T, val: U| *callback(arg) = val)
     }
 
     /// Register an indexer function for a registered type with the `Engine`.

--- a/src/engine.rs
+++ b/src/engine.rs
@@ -990,8 +990,6 @@ impl Engine {
                             &mut tmp
                         }
                     };
-                    // TODO: Going along with my function reform, I'd like to see new_val become a Dynamic
-                    // in setters to minimize cloning.
                     let mut args = [obj, new_val.as_mut().unwrap()];
                     self.exec_fn_call(fn_lib, &fn_name, &mut args, None, *pos, 0).map(|_| ().into())
                 }

--- a/tests/get_set.rs
+++ b/tests/get_set.rs
@@ -46,7 +46,7 @@ fn test_get_set() -> Result<(), Box<EvalAltResult>> {
     engine.register_fn("new_ts", TestStruct::new);
 
     #[cfg(not(feature = "no_index"))]
-    engine.register_mut_indexer(|value, index| &mut value.array[index as usize]);
+    engine.register_mut_indexer(|value: &mut TestStruct, index: INT| &mut value.array[index as usize]);
 
     assert_eq!(engine.eval::<INT>("let a = new_ts(); a.x = 500; a.x")?, 500);
     assert_eq!(engine.eval::<INT>("let a = new_ts(); a.x.add(); a.x")?, 42);

--- a/tests/get_set.rs
+++ b/tests/get_set.rs
@@ -12,8 +12,8 @@ fn test_get_set() -> Result<(), Box<EvalAltResult>> {
     }
 
     impl TestStruct {
-        fn get_x(&mut self) -> INT {
-            self.x
+        fn get_mut_x(&mut self) -> &mut INT {
+            &mut self.x
         }
 
         fn set_x(&mut self, new_x: INT) {
@@ -37,7 +37,10 @@ fn test_get_set() -> Result<(), Box<EvalAltResult>> {
 
     engine.register_type::<TestStruct>();
 
-    engine.register_get_set("x", TestStruct::get_x, TestStruct::set_x);
+    engine.register_get_mut("x", TestStruct::get_mut_x);
+    // TODO: Make this redundant
+    engine.register_get("x", |s: &mut TestStruct| *s.get_mut_x());
+    engine.register_set("x", TestStruct::set_x);
     engine.register_get("y", TestStruct::get_y);
     engine.register_fn("add", |value: &mut INT| *value += 41);
     engine.register_fn("new_ts", TestStruct::new);
@@ -82,12 +85,8 @@ fn test_big_get_set() -> Result<(), Box<EvalAltResult>> {
     }
 
     impl TestParent {
-        fn get_child(&mut self) -> TestChild {
-            self.child.clone()
-        }
-
-        fn set_child(&mut self, new_child: TestChild) {
-            self.child = new_child;
+        fn get_mut_child(&mut self) -> &mut TestChild {
+            &mut self.child
         }
 
         fn new() -> TestParent {
@@ -103,7 +102,7 @@ fn test_big_get_set() -> Result<(), Box<EvalAltResult>> {
     engine.register_type_with_name::<TestParent>("TestParent");
 
     engine.register_get_set("x", TestChild::get_x, TestChild::set_x);
-    engine.register_get_set("child", TestParent::get_child, TestParent::set_child);
+    engine.register_get_mut("child", TestParent::get_mut_child);
 
     engine.register_fn("new_tp", TestParent::new);
 

--- a/tests/get_set.rs
+++ b/tests/get_set.rs
@@ -46,7 +46,7 @@ fn test_get_set() -> Result<(), Box<EvalAltResult>> {
     engine.register_fn("new_ts", TestStruct::new);
 
     #[cfg(not(feature = "no_index"))]
-    engine.register_indexer(|value: &mut TestStruct, index: INT| value.array[index as usize]);
+    engine.register_mut_indexer(|value, index| &mut value.array[index as usize]);
 
     assert_eq!(engine.eval::<INT>("let a = new_ts(); a.x = 500; a.x")?, 500);
     assert_eq!(engine.eval::<INT>("let a = new_ts(); a.x.add(); a.x")?, 42);


### PR DESCRIPTION
This is the "hard part" of the changes necessary for a (soon to be posted) proposal on modifying how getters, setters, and mutating methods work. It performs all the necessary work to get the rust type system to accept things, but otherwise isn't complete. In particular methods were not modified to work with the new system, string indexing was stubbed out, type_name on Target probably returns the wrong thing, at least one place that returns an errror instead just calls `unimplemented!()`, ~~indexing of non `Dynamic` maps/arrays wasn't implemented~~, and `get_mut` really should register getters and setters as well, but doesn't yet.