### PR TITLE
Basic Implementation of Plugins and Plugin Functions

### DIFF
--- a/src/engine.rs
+++ b/src/engine.rs
@@ -1652,6 +1652,7 @@ impl Engine {
                         let mut scope = Scope::new();
                         self.call_script_fn(&mut scope, state, lib, name, fn_def, args, *pos, level)
                     }
+                    Ok(x) if x.is_plugin_fn() => x.get_plugin_fn().call(args.as_mut(), *pos),
                     Ok(x) => x.get_native_fn()(args.as_mut()).map_err(|err| err.new_position(*pos)),
                     Err(err)
                         if def_val.is_some()

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -75,10 +75,14 @@ mod engine;
 mod error;
 mod fn_call;
 mod fn_func;
-mod fn_native;
+pub mod fn_native;
 mod fn_register;
 mod module;
 mod optimize;
+#[cfg(not(feature = "no_module"))]
+pub mod plugin;
+#[cfg(feature = "no_module")]
+mod plugin;
 pub mod packages;
 mod parser;
 mod result;
@@ -91,9 +95,8 @@ mod utils;
 pub use any::Dynamic;
 pub use engine::Engine;
 pub use error::{ParseError, ParseErrorType};
-#[cfg(feature = "plugins")]
-pub use fn_register::{Plugin, RegisterPlugin};
 pub use fn_register::{RegisterFn, RegisterResultFn};
+pub use fn_register::RegisterPlugin;
 pub use module::Module;
 pub use parser::{ImmutableString, AST, INT};
 pub use result::EvalAltResult;

--- a/src/plugin.rs
+++ b/src/plugin.rs
@@ -1,0 +1,42 @@
+//! Module defining plugins in Rhai. Is exported for use by plugin authors.
+
+pub use crate::Engine;
+pub use crate::any::{Dynamic, Variant};
+pub use crate::fn_native::{CallableFunction, FnCallArgs, IteratorFn};
+pub use crate::parser::{
+    FnAccess,
+    FnAccess::{Private, Public},
+    AST,
+};
+pub use crate::result::EvalAltResult;
+pub use crate::scope::{Entry as ScopeEntry, EntryType as ScopeEntryType, Scope};
+pub use crate::token::{Position, Token};
+pub use crate::utils::StaticVec;
+
+#[cfg(features = "sync")]
+/// Represents an externally-written plugin for the Rhai interpreter.
+///
+/// This trait should not be used directly. Use the `#[plugin]` procedural attribute instead.
+pub trait Plugin: Send {
+    fn register_contents(self, engine: &mut Engine);
+}
+
+#[cfg(not(features = "sync"))]
+/// Represents an externally-written plugin for the Rhai interpreter.
+///
+/// This trait should not be used directly. Use the `#[plugin]` procedural attribute instead.
+pub trait Plugin: Send + Sync {
+    fn register_contents(self, engine: &mut Engine);
+}
+
+/// Represents a function that is statically defined within a plugin.
+///
+/// This trait should not be used directly. Use the `#[plugin]` procedural attribute instead.
+pub trait PluginFunction {
+    fn is_method_call(&self) -> bool;
+    fn is_varadic(&self) -> bool;
+
+    fn call(&self, args: &[&mut Dynamic], pos: Position) -> Result<Dynamic, Box<EvalAltResult>>;
+
+    fn clone_boxed(&self) -> Box<dyn PluginFunction>;
+}


### PR DESCRIPTION
At long last, here it is: plugins as I originally envisioned them.

In order to achieve this, I had to also add "lazy modules" as a concept. That is, modules who defer lookups on their contents until they are accessed. Currently such modules can only be implemented in plugins,  but that is an accident of the implementation. I tried to make sure the concept could be extended later if it was useful.

The way I integrated "lazy modules" into the existing module code is rather ugly. Suggestions or cleanup fixes afterwords are welcome (so long as my one new test does not break).