### PR TITLE
Clean up or suppress all warnings

### DIFF
--- a/src/fn_native.rs
+++ b/src/fn_native.rs
@@ -11,7 +11,7 @@ use crate::utils::{ImmutableString, StaticVec};
 use crate::Scope;
 
 use crate::stdlib::{
-    boxed::Box, convert::TryFrom, fmt, mem, rc::Rc, string::String, sync::Arc, vec::Vec,
+    boxed::Box, convert::TryFrom, fmt, mem, rc::Rc, string::String, vec::Vec,
 };
 
 /// Trait that maps to `Send + Sync` only under the `sync` feature.

--- a/src/packages/mod.rs
+++ b/src/packages/mod.rs
@@ -1,3 +1,5 @@
+#![allow(unused)]
+
 //! Module containing all built-in _packages_ available to Rhai, plus facilities to define custom packages.
 
 use crate::fn_native::{CallableFunction, IteratorFn, Shared};

--- a/src/packages/time_basic.rs
+++ b/src/packages/time_basic.rs
@@ -1,12 +1,8 @@
 #![cfg(not(feature = "no_std"))]
 use super::logic::{eq, gt, gte, lt, lte, ne};
-use super::math_basic::MAX_INT;
 
 use crate::def_package;
-use crate::module::FuncReturn;
-use crate::parser::INT;
 use crate::result::EvalAltResult;
-use crate::token::Position;
 
 #[cfg(not(target_arch = "wasm32"))]
 use crate::stdlib::time::Instant;

--- a/src/syntax.rs
+++ b/src/syntax.rs
@@ -16,7 +16,6 @@ use crate::stdlib::{
     fmt, format,
     rc::Rc,
     string::{String, ToString},
-    sync::Arc,
 };
 
 /// A general expression evaluation trait object.

--- a/tests/time.rs
+++ b/tests/time.rs
@@ -1,7 +1,7 @@
 #![cfg(not(feature = "no_std"))]
 #![cfg(not(target_arch = "wasm32"))]
 
-use rhai::{Engine, EvalAltResult, INT};
+use rhai::{Engine, EvalAltResult};
 
 #[cfg(not(feature = "no_float"))]
 use rhai::FLOAT;


### PR DESCRIPTION
I am currently writing some macro error tests with [trybuild](https://docs.rs/trybuild/1.0.30/trybuild), which does comparison on actual compiler output. The current warnings about unused items and imports are making those cases fail.

This cleans them up.