### PR TITLE
Autocurry feature

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,7 +32,7 @@ only_i64 = []       # set INT=i64 (default) and disable support for all other in
 no_index = []       # no arrays and indexing
 no_object = []      # no custom objects
 no_function = []    # no script-defined functions
-no_closures = []    # no automatic read/write binding of anonymous function's local variables to it's external context
+no_capture = []     # no automatic read/write binding of anonymous function's local variables to it's external context
 no_module = []      # no modules
 internals = []      # expose internal data structures
 unicode-xid-ident = ["unicode-xid"]  # allow Unicode Standard Annex #31 for identifiers.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,6 +32,7 @@ only_i64 = []       # set INT=i64 (default) and disable support for all other in
 no_index = []       # no arrays and indexing
 no_object = []      # no custom objects
 no_function = []    # no script-defined functions
+no_closures = []    # no automatic read/write binding of anonymous function's local variables to it's external context
 no_module = []      # no modules
 internals = []      # expose internal data structures
 unicode-xid-ident = ["unicode-xid"]  # allow Unicode Standard Annex #31 for identifiers.

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -1835,7 +1835,7 @@ fn parse_unary(
             let mut new_state = ParseState::new(
                 state.engine,
                 #[cfg(not(feature = "unchecked"))]
-                state.max_expr_depth,
+                state.max_function_expr_depth,
                 #[cfg(not(feature = "unchecked"))]
                 state.max_function_expr_depth,
             );
@@ -2884,7 +2884,7 @@ fn parse_stmt(
                     let mut state = ParseState::new(
                         state.engine,
                         #[cfg(not(feature = "unchecked"))]
-                        state.max_expr_depth,
+                        state.max_function_expr_depth,
                         #[cfg(not(feature = "unchecked"))]
                         state.max_function_expr_depth,
                     );

--- a/tests/call_fn.rs
+++ b/tests/call_fn.rs
@@ -211,7 +211,7 @@ fn test_fn_ptr_curry_call() -> Result<(), Box<EvalAltResult>> {
 }
 
 #[test]
-#[cfg(not(feature = "no_closures"))]
+#[cfg(not(feature = "no_capture"))]
 fn test_fn_closures() -> Result<(), Box<EvalAltResult>> {
     let engine = Engine::new();
 

--- a/tests/call_fn.rs
+++ b/tests/call_fn.rs
@@ -209,3 +209,24 @@ fn test_fn_ptr_curry_call() -> Result<(), Box<EvalAltResult>> {
 
     Ok(())
 }
+
+#[test]
+fn test_fn_closures() -> Result<(), Box<EvalAltResult>> {
+    let mut engine = Engine::new();
+
+    let res = engine.eval::<INT>(
+        r#"
+            let x = 100;
+
+            let f = || x;
+
+            let x = 200;
+
+            f.call()
+        "#
+    ).unwrap();
+
+    panic!("{:#?}", res);
+
+    Ok(())
+}

--- a/tests/call_fn.rs
+++ b/tests/call_fn.rs
@@ -211,22 +211,26 @@ fn test_fn_ptr_curry_call() -> Result<(), Box<EvalAltResult>> {
 }
 
 #[test]
+#[cfg(not(feature = "no_closures"))]
 fn test_fn_closures() -> Result<(), Box<EvalAltResult>> {
-    let mut engine = Engine::new();
+    let engine = Engine::new();
 
-    let res = engine.eval::<INT>(
-        r#"
-            let x = 100;
+    assert_eq!(
+        engine.eval::<INT>(
+            r#"
+                let x = 8;
 
-            let f = || x;
+                let res = |y, z| {
+                    let w = 12;
 
-            let x = 200;
+                    return (|| x + y + z + w).call();
+                }.curry(15).call(2);
 
-            f.call()
-        "#
-    ).unwrap();
-
-    panic!("{:#?}", res);
+                res + (|| x - 3).call()
+            "#
+        )?,
+        42
+    );
 
     Ok(())
 }


### PR DESCRIPTION
Automatic curry-ing of all undeclared variables inside anonymous functions to the function's external context by implicitly enriching function's list of parameters. This feature is optional and can be opted-out through the new `no_closures` feature.

This PR is a first part of implementation of true mutable closures.