### PR TITLE
Improve proc macro hygiene

### DIFF
--- a/codegen/src/lib.rs
+++ b/codegen/src/lib.rs
@@ -4,7 +4,7 @@
 //! # Exporting a Macro to Rhai
 //!
 //! ```
-//! use rhai::{EvalAltResult, FLOAT, RegisterFn};
+//! use rhai::{EvalAltResult, FLOAT};
 //! use rhai::plugin::*;
 //! use rhai::module_resolvers::*;
 //!
@@ -144,8 +144,8 @@ pub fn register_exported_fn(args: proc_macro::TokenStream) -> proc_macro::TokenS
     };
     let tokens = quote! {
         #rhai_module.set_fn(#export_name, rhai::FnAccess::Public,
-                            #gen_mod_path::Token().input_types().as_ref(),
-                            CallableFunction::from_plugin(#gen_mod_path::Token()));
+                            #gen_mod_path::Token__input_types().as_ref(),
+                            #gen_mod_path::Token__callable());
 
     };
     proc_macro::TokenStream::from(tokens)

--- a/codegen/src/module.rs
+++ b/codegen/src/module.rs
@@ -263,7 +263,7 @@ mod generate_tests {
         let expected_tokens = quote! {
             pub mod empty {
                 #[allow(unused_imports)]
-                use rhai::{Module, FnAccess};
+                use super::*;
                 #[allow(unused_mut)]
                 pub fn rhai_module__generate() -> Module {
                     let mut m = Module::new();
@@ -292,36 +292,42 @@ mod generate_tests {
                     42
                 }
                 #[allow(unused_imports)]
-                use rhai::{Module, FnAccess};
+                use super::*;
                 #[allow(unused_mut)]
                 pub fn rhai_module__generate() -> Module {
                     let mut m = Module::new();
                     m.set_fn("get_mystic_number", FnAccess::Public, &[],
-                             rhai::plugin::CallableFunction::from_plugin(get_mystic_number__Token()));
+                             CallableFunction::from_plugin(get_mystic_number__Token()));
                     m
                 }
                 #[allow(non_camel_case_types)]
-                pub struct get_mystic_number__Token();
-                impl rhai::plugin::PluginFunction for get_mystic_number__Token {
+                struct get_mystic_number__Token();
+                impl PluginFunction for get_mystic_number__Token {
                     fn call(&self,
-                            args: &mut [&mut rhai::Dynamic], pos: rhai::Position
-                    ) -> Result<rhai::Dynamic, Box<rhai::EvalAltResult>> {
+                            args: &mut [&mut Dynamic], pos: Position
+                    ) -> Result<Dynamic, Box<EvalAltResult>> {
                         if args.len() != 0usize {
-                            return Err(Box::new(rhai::EvalAltResult::ErrorRuntime(
+                            return Err(Box::new(EvalAltResult::ErrorRuntime(
                                     format!("wrong arg count: {} != {}",
-                                            args.len(), 0usize), rhai::Position::none())));
+                                            args.len(), 0usize), Position::none())));
                         }
-                        Ok(rhai::Dynamic::from(get_mystic_number()))
+                        Ok(Dynamic::from(get_mystic_number()))
                     }
 
                     fn is_method_call(&self) -> bool { false }
                     fn is_varadic(&self) -> bool { false }
-                    fn clone_boxed(&self) -> Box<dyn rhai::plugin::PluginFunction> {
+                    fn clone_boxed(&self) -> Box<dyn PluginFunction> {
                         Box::new(get_mystic_number__Token())
                     }
                     fn input_types(&self) -> Box<[std::any::TypeId]> {
                         vec![].into_boxed_slice()
                     }
+                }
+                pub fn get_mystic_number__Token__callable() -> CallableFunction {
+                    CallableFunction::from_plugin(get_mystic_number__Token())
+                }
+                pub fn get_mystic_number__Token__input_types() -> Box<[std::any::TypeId]> {
+                    get_mystic_number__Token().input_types()
                 }
             }
         };
@@ -346,37 +352,43 @@ mod generate_tests {
                     x + 1
                 }
                 #[allow(unused_imports)]
-                use rhai::{Module, FnAccess};
+                use super::*;
                 #[allow(unused_mut)]
                 pub fn rhai_module__generate() -> Module {
                     let mut m = Module::new();
                     m.set_fn("add_one_to", FnAccess::Public, &[core::any::TypeId::of::<INT>()],
-                             rhai::plugin::CallableFunction::from_plugin(add_one_to__Token()));
+                             CallableFunction::from_plugin(add_one_to__Token()));
                     m
                 }
                 #[allow(non_camel_case_types)]
-                pub struct add_one_to__Token();
-                impl rhai::plugin::PluginFunction for add_one_to__Token {
+                struct add_one_to__Token();
+                impl PluginFunction for add_one_to__Token {
                     fn call(&self,
-                            args: &mut [&mut rhai::Dynamic], pos: rhai::Position
-                    ) -> Result<rhai::Dynamic, Box<rhai::EvalAltResult>> {
+                            args: &mut [&mut Dynamic], pos: Position
+                    ) -> Result<Dynamic, Box<EvalAltResult>> {
                         if args.len() != 1usize {
-                            return Err(Box::new(rhai::EvalAltResult::ErrorRuntime(
+                            return Err(Box::new(EvalAltResult::ErrorRuntime(
                                     format!("wrong arg count: {} != {}",
-                                            args.len(), 1usize), rhai::Position::none())));
+                                            args.len(), 1usize), Position::none())));
                         }
                         let arg0 = args[0usize].downcast_clone::<INT>().unwrap();
-                        Ok(rhai::Dynamic::from(add_one_to(arg0)))
+                        Ok(Dynamic::from(add_one_to(arg0)))
                     }
 
                     fn is_method_call(&self) -> bool { false }
                     fn is_varadic(&self) -> bool { false }
-                    fn clone_boxed(&self) -> Box<dyn rhai::plugin::PluginFunction> {
+                    fn clone_boxed(&self) -> Box<dyn PluginFunction> {
                         Box::new(add_one_to__Token())
                     }
                     fn input_types(&self) -> Box<[std::any::TypeId]> {
                         vec![std::any::TypeId::of::<INT>()].into_boxed_slice()
                     }
+                }
+                pub fn add_one_to__Token__callable() -> CallableFunction {
+                    CallableFunction::from_plugin(add_one_to__Token())
+                }
+                pub fn add_one_to__Token__input_types() -> Box<[std::any::TypeId]> {
+                    add_one_to__Token().input_types()
                 }
             }
         };
@@ -401,40 +413,46 @@ mod generate_tests {
                     x + y
                 }
                 #[allow(unused_imports)]
-                use rhai::{Module, FnAccess};
+                use super::*;
                 #[allow(unused_mut)]
                 pub fn rhai_module__generate() -> Module {
                     let mut m = Module::new();
                     m.set_fn("add_together", FnAccess::Public, &[core::any::TypeId::of::<INT>(),
                                                                  core::any::TypeId::of::<INT>()],
-                             rhai::plugin::CallableFunction::from_plugin(add_together__Token()));
+                             CallableFunction::from_plugin(add_together__Token()));
                     m
                 }
                 #[allow(non_camel_case_types)]
-                pub struct add_together__Token();
-                impl rhai::plugin::PluginFunction for add_together__Token {
+                struct add_together__Token();
+                impl PluginFunction for add_together__Token {
                     fn call(&self,
-                            args: &mut [&mut rhai::Dynamic], pos: rhai::Position
-                    ) -> Result<rhai::Dynamic, Box<rhai::EvalAltResult>> {
+                            args: &mut [&mut Dynamic], pos: Position
+                    ) -> Result<Dynamic, Box<EvalAltResult>> {
                         if args.len() != 2usize {
-                            return Err(Box::new(rhai::EvalAltResult::ErrorRuntime(
+                            return Err(Box::new(EvalAltResult::ErrorRuntime(
                                     format!("wrong arg count: {} != {}",
-                                            args.len(), 2usize), rhai::Position::none())));
+                                            args.len(), 2usize), Position::none())));
                         }
                         let arg0 = args[0usize].downcast_clone::<INT>().unwrap();
                         let arg1 = args[1usize].downcast_clone::<INT>().unwrap();
-                        Ok(rhai::Dynamic::from(add_together(arg0, arg1)))
+                        Ok(Dynamic::from(add_together(arg0, arg1)))
                     }
 
                     fn is_method_call(&self) -> bool { false }
                     fn is_varadic(&self) -> bool { false }
-                    fn clone_boxed(&self) -> Box<dyn rhai::plugin::PluginFunction> {
+                    fn clone_boxed(&self) -> Box<dyn PluginFunction> {
                         Box::new(add_together__Token())
                     }
                     fn input_types(&self) -> Box<[std::any::TypeId]> {
                         vec![std::any::TypeId::of::<INT>(),
                              std::any::TypeId::of::<INT>()].into_boxed_slice()
                     }
+                }
+                pub fn add_together__Token__callable() -> CallableFunction {
+                    CallableFunction::from_plugin(add_together__Token())
+                }
+                pub fn add_together__Token__input_types() -> Box<[std::any::TypeId]> {
+                    add_together__Token().input_types()
                 }
             }
         };
@@ -455,7 +473,7 @@ mod generate_tests {
             pub mod one_constant {
                 pub const MYSTIC_NUMBER: INT = 42;
                 #[allow(unused_imports)]
-                use rhai::{Module, FnAccess};
+                use super::*;
                 #[allow(unused_mut)]
                 pub fn rhai_module__generate() -> Module {
                     let mut m = Module::new();
@@ -483,7 +501,7 @@ mod generate_tests {
                 pub use rhai::INT;
                 pub const MYSTIC_NUMBER: INT = 42;
                 #[allow(unused_imports)]
-                use rhai::{Module, FnAccess};
+                use super::*;
                 #[allow(unused_mut)]
                 pub fn rhai_module__generate() -> Module {
                     let mut m = Module::new();
@@ -513,7 +531,7 @@ mod generate_tests {
                     42
                 }
                 #[allow(unused_imports)]
-                use rhai::{Module, FnAccess};
+                use super::*;
                 #[allow(unused_mut)]
                 pub fn rhai_module__generate() -> Module {
                     let mut m = Module::new();
@@ -538,7 +556,7 @@ mod generate_tests {
             pub mod one_constant {
                 const MYSTIC_NUMBER: INT = 42;
                 #[allow(unused_imports)]
-                use rhai::{Module, FnAccess};
+                use super::*;
                 #[allow(unused_mut)]
                 pub fn rhai_module__generate() -> Module {
                     let mut m = Module::new();
@@ -567,38 +585,44 @@ mod generate_tests {
                     x + 1
                 }
                 #[allow(unused_imports)]
-                use rhai::{Module, FnAccess};
+                use super::*;
                 #[allow(unused_mut)]
                 pub fn rhai_module__generate() -> Module {
                     let mut m = Module::new();
                     m.set_fn("print_out_to", FnAccess::Public,
-                             &[core::any::TypeId::of::<rhai::ImmutableString>()],
-                             rhai::plugin::CallableFunction::from_plugin(print_out_to__Token()));
+                             &[core::any::TypeId::of::<ImmutableString>()],
+                             CallableFunction::from_plugin(print_out_to__Token()));
                     m
                 }
                 #[allow(non_camel_case_types)]
-                pub struct print_out_to__Token();
-                impl rhai::plugin::PluginFunction for print_out_to__Token {
+                struct print_out_to__Token();
+                impl PluginFunction for print_out_to__Token {
                     fn call(&self,
-                            args: &mut [&mut rhai::Dynamic], pos: rhai::Position
-                    ) -> Result<rhai::Dynamic, Box<rhai::EvalAltResult>> {
+                            args: &mut [&mut Dynamic], pos: Position
+                    ) -> Result<Dynamic, Box<EvalAltResult>> {
                         if args.len() != 1usize {
-                            return Err(Box::new(rhai::EvalAltResult::ErrorRuntime(
+                            return Err(Box::new(EvalAltResult::ErrorRuntime(
                                     format!("wrong arg count: {} != {}",
-                                            args.len(), 1usize), rhai::Position::none())));
+                                            args.len(), 1usize), Position::none())));
                         }
-                        let arg0 = args[0usize].downcast_clone::<rhai::ImmutableString>().unwrap();
-                        Ok(rhai::Dynamic::from(print_out_to(&arg0)))
+                        let arg0 = args[0usize].downcast_clone::<ImmutableString>().unwrap();
+                        Ok(Dynamic::from(print_out_to(&arg0)))
                     }
 
                     fn is_method_call(&self) -> bool { false }
                     fn is_varadic(&self) -> bool { false }
-                    fn clone_boxed(&self) -> Box<dyn rhai::plugin::PluginFunction> {
+                    fn clone_boxed(&self) -> Box<dyn PluginFunction> {
                         Box::new(print_out_to__Token())
                     }
                     fn input_types(&self) -> Box<[std::any::TypeId]> {
-                        vec![std::any::TypeId::of::<rhai::ImmutableString>()].into_boxed_slice()
+                        vec![std::any::TypeId::of::<ImmutableString>()].into_boxed_slice()
                     }
+                }
+                pub fn print_out_to__Token__callable() -> CallableFunction {
+                    CallableFunction::from_plugin(print_out_to__Token())
+                }
+                pub fn print_out_to__Token__input_types() -> Box<[std::any::TypeId]> {
+                    print_out_to__Token().input_types()
                 }
             }
         };
@@ -623,40 +647,46 @@ mod generate_tests {
                     *x += 1.0 as FLOAT;
                 }
                 #[allow(unused_imports)]
-                use rhai::{Module, FnAccess};
+                use super::*;
                 #[allow(unused_mut)]
                 pub fn rhai_module__generate() -> Module {
                     let mut m = Module::new();
                     m.set_fn("increment", FnAccess::Public,
                              &[core::any::TypeId::of::<FLOAT>()],
-                             rhai::plugin::CallableFunction::from_plugin(increment__Token()));
+                             CallableFunction::from_plugin(increment__Token()));
                     m
                 }
                 #[allow(non_camel_case_types)]
-                pub struct increment__Token();
-                impl rhai::plugin::PluginFunction for increment__Token {
+                struct increment__Token();
+                impl PluginFunction for increment__Token {
                     fn call(&self,
-                            args: &mut [&mut rhai::Dynamic], pos: rhai::Position
-                    ) -> Result<rhai::Dynamic, Box<rhai::EvalAltResult>> {
+                            args: &mut [&mut Dynamic], pos: Position
+                    ) -> Result<Dynamic, Box<EvalAltResult>> {
                         if args.len() != 1usize {
-                            return Err(Box::new(rhai::EvalAltResult::ErrorRuntime(
+                            return Err(Box::new(EvalAltResult::ErrorRuntime(
                                     format!("wrong arg count: {} != {}",
-                                            args.len(), 1usize), rhai::Position::none())));
+                                            args.len(), 1usize), Position::none())));
                         }
                         let arg0: &mut _ = args[0usize].downcast_mut::<FLOAT>().unwrap();
-                        Ok(rhai::Dynamic::from(increment(arg0)))
+                        Ok(Dynamic::from(increment(arg0)))
                     }
 
                     fn is_method_call(&self) -> bool { true }
                     fn is_varadic(&self) -> bool { false }
-                    fn clone_boxed(&self) -> Box<dyn rhai::plugin::PluginFunction> {
+                    fn clone_boxed(&self) -> Box<dyn PluginFunction> {
                         Box::new(increment__Token())
                     }
                     fn input_types(&self) -> Box<[std::any::TypeId]> {
                         vec![std::any::TypeId::of::<FLOAT>()].into_boxed_slice()
                     }
                 }
-            }
+                pub fn increment__Token__callable() -> CallableFunction {
+                    CallableFunction::from_plugin(increment__Token())
+                }
+                pub fn increment__Token__input_types() -> Box<[std::any::TypeId]> {
+                    increment__Token().input_types()
+                }
+        }
         };
 
         let item_mod = syn::parse2::<Module>(input_tokens).unwrap();

--- a/codegen/src/rhai_module.rs
+++ b/codegen/src/rhai_module.rs
@@ -44,7 +44,7 @@ pub(crate) fn generate_body(
                         }) => match elem.as_ref() {
                             &syn::Type::Path(ref p) if p.path == str_type_path => {
                                 syn::parse2::<syn::Type>(quote! {
-                                rhai::ImmutableString })
+                                ImmutableString })
                                 .unwrap()
                             }
                             _ => panic!("internal error: non-string shared reference!?"),
@@ -71,22 +71,24 @@ pub(crate) fn generate_body(
         set_fn_stmts.push(
             syn::parse2::<syn::Stmt>(quote! {
                 m.set_fn(#fn_literal, FnAccess::Public, &[#(#fn_input_types),*],
-                         rhai::plugin::CallableFunction::from_plugin(#fn_token_name()));
+                         CallableFunction::from_plugin(#fn_token_name()));
             })
             .unwrap(),
         );
 
         gen_fn_tokens.push(quote! {
             #[allow(non_camel_case_types)]
-            pub struct #fn_token_name();
+            struct #fn_token_name();
         });
         gen_fn_tokens.push(function.generate_impl(&fn_token_name.to_string()));
+        gen_fn_tokens.push(function.generate_callable(&fn_token_name.to_string()));
+        gen_fn_tokens.push(function.generate_input_types(&fn_token_name.to_string()));
     }
 
     let mut generate_fncall = syn::parse2::<syn::ItemMod>(quote! {
         pub mod generate_info {
             #[allow(unused_imports)]
-            use rhai::{Module, FnAccess};
+            use super::*;
             #[allow(unused_mut)]
             pub fn rhai_module__generate() -> Module {
                 let mut m = Module::new();

--- a/codegen/tests/test_functions.rs
+++ b/codegen/tests/test_functions.rs
@@ -1,9 +1,8 @@
 use rhai::module_resolvers::*;
-use rhai::plugin::*;
-use rhai::{EvalAltResult, Module, RegisterFn, FLOAT, INT};
+use rhai::{Engine, EvalAltResult, Module, RegisterFn, FLOAT, INT};
 
 pub mod raw_fn {
-    use rhai::export_fn;
+    use rhai::plugin::*;
     use rhai::FLOAT;
 
     #[export_fn]
@@ -37,7 +36,7 @@ fn raw_fn_test() -> Result<(), Box<EvalAltResult>> {
 }
 
 mod raw_fn_mut {
-    use rhai::export_fn;
+    use rhai::plugin::*;
     use rhai::FLOAT;
 
     #[export_fn]
@@ -69,7 +68,7 @@ fn raw_fn_mut_test() -> Result<(), Box<EvalAltResult>> {
 }
 
 mod raw_fn_str {
-    use rhai::export_fn;
+    use rhai::plugin::*;
 
     #[export_fn]
     pub fn write_out_str(message: &str) -> bool {
@@ -100,7 +99,7 @@ fn raw_fn_str_test() -> Result<(), Box<EvalAltResult>> {
 }
 
 mod mut_opaque_ref {
-    use rhai::export_fn;
+    use rhai::plugin::*;
     use rhai::INT;
 
     #[derive(Clone)]

--- a/codegen/tests/test_modules.rs
+++ b/codegen/tests/test_modules.rs
@@ -1,9 +1,8 @@
 use rhai::module_resolvers::*;
-use rhai::plugin::*;
-use rhai::{EvalAltResult, RegisterFn, FLOAT, INT};
+use rhai::{Engine, EvalAltResult, RegisterFn, FLOAT, INT};
 
 pub mod empty_module {
-    use rhai::export_module;
+    use rhai::plugin::*;
 
     #[export_module]
     pub mod EmptyModule {}
@@ -25,7 +24,7 @@ fn empty_module_test() -> Result<(), Box<EvalAltResult>> {
 }
 
 pub mod one_fn_module {
-    use rhai::export_module;
+    use rhai::plugin::*;
 
     #[export_module]
     pub mod advanced_math {
@@ -56,7 +55,7 @@ fn one_fn_module_test() -> Result<(), Box<EvalAltResult>> {
 }
 
 pub mod one_fn_and_const_module {
-    use rhai::export_module;
+    use rhai::plugin::*;
 
     #[export_module]
     pub mod advanced_math {
@@ -91,7 +90,7 @@ fn one_fn_and_const_module_test() -> Result<(), Box<EvalAltResult>> {
 }
 
 pub mod raw_fn_str_module {
-    use rhai::export_module;
+    use rhai::plugin::*;
 
     #[export_module]
     pub mod host_io {
@@ -122,7 +121,7 @@ fn raw_fn_str_module_test() -> Result<(), Box<EvalAltResult>> {
 }
 
 pub mod mut_opaque_ref_module {
-    use rhai::export_module;
+    use rhai::plugin::*;
     use rhai::INT;
 
     #[derive(Clone)]

--- a/codegen/ui_tests/first_shared_ref.rs
+++ b/codegen/ui_tests/first_shared_ref.rs
@@ -1,4 +1,4 @@
-use rhai::export_fn;
+use rhai::plugin::*;
 
 struct NonClonable {
     a: f32,

--- a/codegen/ui_tests/first_shared_ref.stderr
+++ b/codegen/ui_tests/first_shared_ref.stderr
@@ -5,7 +5,7 @@ error: references from Rhai in this position must be mutable
    |                       ^^^^^^^^^^^^
 
 error[E0425]: cannot find function `test_fn` in this scope
-  --> $DIR/first_shared_ref.rs:17:8
+  --> $DIR/first_shared_ref.rs:22:8
    |
-17 |     if test_fn(n) {
+22 |     if test_fn(n) {
    |        ^^^^^^^ not found in this scope

--- a/codegen/ui_tests/non_clonable.rs
+++ b/codegen/ui_tests/non_clonable.rs
@@ -1,4 +1,4 @@
-use rhai::export_fn;
+use rhai::plugin::*;
 
 struct NonClonable {
     a: f32,

--- a/codegen/ui_tests/non_clonable_second.rs
+++ b/codegen/ui_tests/non_clonable_second.rs
@@ -1,4 +1,4 @@
-use rhai::export_fn;
+use rhai::plugin::*;
 
 struct NonClonable {
     a: f32,

--- a/codegen/ui_tests/return_mut_ref.rs
+++ b/codegen/ui_tests/return_mut_ref.rs
@@ -1,4 +1,4 @@
-use rhai::export_fn;
+use rhai::plugin::*;
 
 #[derive(Clone)]
 struct Clonable {

--- a/codegen/ui_tests/return_mut_ref.stderr
+++ b/codegen/ui_tests/return_mut_ref.stderr
@@ -5,7 +5,7 @@ error: cannot return a reference to Rhai
    |                                      ^^^^^^^^^^^^
 
 error[E0425]: cannot find function `test_fn` in this scope
-  --> $DIR/return_mut_ref.rs:18:8
+  --> $DIR/return_mut_ref.rs:23:8
    |
-18 |     if test_fn(n) {
+23 |     if test_fn(n) {
    |        ^^^^^^^ not found in this scope

--- a/codegen/ui_tests/return_pointer.rs
+++ b/codegen/ui_tests/return_pointer.rs
@@ -1,4 +1,4 @@
-use rhai::export_fn;
+use rhai::plugin::*;
 
 #[derive(Clone)]
 struct Clonable {

--- a/codegen/ui_tests/return_pointer.stderr
+++ b/codegen/ui_tests/return_pointer.stderr
@@ -5,7 +5,7 @@ error: cannot return a pointer to Rhai
    |                                 ^^^^^^^^^^^^^
 
 error[E0425]: cannot find function `test_fn` in this scope
-  --> $DIR/return_pointer.rs:18:39
+  --> $DIR/return_pointer.rs:24:19
    |
-18 |     println!("{}", unsafe { let ptr = test_fn(n); *ptr });
-   |                                       ^^^^^^^ not found in this scope
+24 |         let ptr = test_fn(n);
+   |                   ^^^^^^^ not found in this scope

--- a/codegen/ui_tests/return_shared_ref.rs
+++ b/codegen/ui_tests/return_shared_ref.rs
@@ -1,4 +1,4 @@
-use rhai::export_fn;
+use rhai::plugin::*;
 
 #[derive(Clone)]
 struct Clonable {

--- a/codegen/ui_tests/return_shared_ref.stderr
+++ b/codegen/ui_tests/return_shared_ref.stderr
@@ -1,11 +1,11 @@
 error: cannot return a reference to Rhai
   --> $DIR/return_shared_ref.rs:12:33
    |
-12 | pub fn test_fn(input: Clonable) -> & 'static str {
-   |                                 ^^^^^^^^^^^^^^^^
+12 | pub fn test_fn(input: Clonable) -> &'static str {
+   |                                 ^^^^^^^^^^^^^^^
 
 error[E0425]: cannot find function `test_fn` in this scope
-  --> $DIR/return_shared_ref.rs:18:20
+  --> $DIR/return_shared_ref.rs:23:20
    |
-18 |     println!("{}", test_fn(n));
+23 |     println!("{}", test_fn(n));
    |                    ^^^^^^^ not found in this scope

--- a/codegen/ui_tests/second_shared_ref.rs
+++ b/codegen/ui_tests/second_shared_ref.rs
@@ -1,4 +1,4 @@
-use rhai::export_fn;
+use rhai::plugin::*;
 
 #[derive(Clone)]
 pub struct Clonable {

--- a/codegen/ui_tests/second_shared_ref.stderr
+++ b/codegen/ui_tests/second_shared_ref.stderr
@@ -5,7 +5,7 @@ error: this type in this position passes from Rhai by value
    |                                         ^^^^^
 
 error[E0425]: cannot find function `test_fn` in this scope
-  --> $DIR/second_shared_ref.rs:18:8
+  --> $DIR/second_shared_ref.rs:23:8
    |
-18 |     if test_fn(n, &true) {
+23 |     if test_fn(n, &true) {
    |        ^^^^^^^ not found in this scope

--- a/src/plugin.rs
+++ b/src/plugin.rs
@@ -2,11 +2,18 @@
 
 use crate::stdlib::{any::TypeId, boxed::Box};
 
-use crate::any::Dynamic;
-use crate::engine::Engine;
-pub use crate::fn_native::CallableFunction;
-use crate::result::EvalAltResult;
-use crate::token::Position;
+pub use crate::{
+    fn_native::CallableFunction,
+    Dynamic,
+    Engine,
+    EvalAltResult,
+    FnAccess,
+    ImmutableString,
+    Module,
+    Position,
+};
+
+pub use rhai_codegen::*;
 
 #[cfg(features = "sync")]
 /// Represents an externally-written plugin for the Rhai interpreter.

--- a/tests/plugins.rs
+++ b/tests/plugins.rs
@@ -1,8 +1,4 @@
-use rhai::{
-    export_fn, export_module, exported_module,
-    plugin::{CallableFunction, PluginFunction},
-    register_exported_fn,
-};
+use rhai::plugin::*;
 use rhai::{Engine, EvalAltResult, INT};
 
 #[export_module]


### PR DESCRIPTION
This hides all items used by the module behind a single import: `rhai::plugin::*`.

Examples and tests are updated to verify this minimal import provides good hygiene for everything.