### PR TITLE
export_fn: add "name" parameter

### DIFF
--- a/codegen/src/lib.rs
+++ b/codegen/src/lib.rs
@@ -76,12 +76,13 @@ mod rhai_module;
 
 #[proc_macro_attribute]
 pub fn export_fn(
-    _args: proc_macro::TokenStream,
+    args: proc_macro::TokenStream,
     input: proc_macro::TokenStream,
 ) -> proc_macro::TokenStream {
     let mut output = proc_macro2::TokenStream::from(input.clone());
+    let parsed_params = parse_macro_input!(args as function::ExportedFnParams);
     let function_def = parse_macro_input!(input as function::ExportedFn);
-    output.extend(function_def.generate());
+    output.extend(function_def.generate_with_params(parsed_params));
     proc_macro::TokenStream::from(output)
 }
 

--- a/codegen/ui_tests/export_fn_bad_attr.rs
+++ b/codegen/ui_tests/export_fn_bad_attr.rs
@@ -1,0 +1,24 @@
+use rhai::plugin::*;
+
+#[derive(Clone)]
+struct Point {
+    x: f32,
+    y: f32,
+}
+
+#[export_fn(unknown = true)]
+pub fn test_fn(input: Point) -> bool {
+    input.x > input.y
+}
+
+fn main() {
+    let n = Point {
+        x: 0.0,
+        y: 10.0,
+    };
+    if test_fn(n) {
+        println!("yes");
+    } else {
+        println!("no");
+    }
+}

--- a/codegen/ui_tests/export_fn_bad_attr.stderr
+++ b/codegen/ui_tests/export_fn_bad_attr.stderr
@@ -1,0 +1,11 @@
+error: unknown attribute 'unknown'
+ --> $DIR/export_fn_bad_attr.rs:9:13
+  |
+9 | #[export_fn(unknown = true)]
+  |             ^^^^^^^
+
+error[E0425]: cannot find function `test_fn` in this scope
+  --> $DIR/export_fn_bad_attr.rs:19:8
+   |
+19 |     if test_fn(n) {
+   |        ^^^^^^^ not found in this scope

--- a/codegen/ui_tests/export_fn_bad_value.rs
+++ b/codegen/ui_tests/export_fn_bad_value.rs
@@ -1,0 +1,24 @@
+use rhai::plugin::*;
+
+#[derive(Clone)]
+struct Point {
+    x: f32,
+    y: f32,
+}
+
+#[export_fn(name = true)]
+pub fn test_fn(input: Point) -> bool {
+    input.x > input.y
+}
+
+fn main() {
+    let n = Point {
+        x: 0.0,
+        y: 10.0,
+    };
+    if test_fn(n) {
+        println!("yes");
+    } else {
+        println!("no");
+    }
+}

--- a/codegen/ui_tests/export_fn_bad_value.stderr
+++ b/codegen/ui_tests/export_fn_bad_value.stderr
@@ -1,0 +1,11 @@
+error: expecting string literal value
+ --> $DIR/export_fn_bad_value.rs:9:20
+  |
+9 | #[export_fn(name = true)]
+  |                    ^^^^
+
+error[E0425]: cannot find function `test_fn` in this scope
+  --> $DIR/export_fn_bad_value.rs:19:8
+   |
+19 |     if test_fn(n) {
+   |        ^^^^^^^ not found in this scope

--- a/codegen/ui_tests/export_fn_junk_arg.rs
+++ b/codegen/ui_tests/export_fn_junk_arg.rs
@@ -1,0 +1,24 @@
+use rhai::plugin::*;
+
+#[derive(Clone)]
+struct Point {
+    x: f32,
+    y: f32,
+}
+
+#[export_fn("wheeeee")]
+pub fn test_fn(input: Point) -> bool {
+    input.x > input.y
+}
+
+fn main() {
+    let n = Point {
+        x: 0.0,
+        y: 10.0,
+    };
+    if test_fn(n) {
+        println!("yes");
+    } else {
+        println!("no");
+    }
+}

--- a/codegen/ui_tests/export_fn_junk_arg.stderr
+++ b/codegen/ui_tests/export_fn_junk_arg.stderr
@@ -1,0 +1,11 @@
+error: expected assignment expression
+ --> $DIR/export_fn_junk_arg.rs:9:13
+  |
+9 | #[export_fn("wheeeee")]
+  |             ^^^^^^^^^
+
+error[E0425]: cannot find function `test_fn` in this scope
+  --> $DIR/export_fn_junk_arg.rs:19:8
+   |
+19 |     if test_fn(n) {
+   |        ^^^^^^^ not found in this scope


### PR DESCRIPTION
Usage is straightforward:

```rust
#[export_fn(name = "add_float")]
pub fn add(f1: FLOAT, f2: FLOAT) -> FLOAT {
    f1 + f2
}
```

This allows avoiding name collisions _in the Rust code_. It has no effect on the way the module is named when registered with Rhai.

At the moment, this does not work within `exported_module`s, but only standalone functions. That is much harder, due to the way nested procedural macros are evaluated.