### PR TITLE
export_fn: allow duplicate Rust fn names before rename

### DIFF
--- a/codegen/src/function.rs
+++ b/codegen/src/function.rs
@@ -4,7 +4,7 @@ use syn::{parse::Parse, parse::ParseStream, spanned::Spanned};
 
 #[derive(Debug, Default)]
 pub(crate) struct ExportedFnParams {
-    name: Option<String>,
+    pub name: Option<String>,
 }
 
 impl Parse for ExportedFnParams {
@@ -238,7 +238,12 @@ impl ExportedFn {
     }
 
     pub fn generate_impl(&self, on_type_name: &str) -> proc_macro2::TokenStream {
-        let name: syn::Ident = self.name().clone();
+        let name: syn::Ident = if let Some(ref name) = self.params.name {
+            syn::Ident::new(name, self.name().span())
+        } else {
+            self.name().clone()
+        };
+
         let arg_count = self.arg_count();
         let is_method_call = self.mutable_receiver();
 

--- a/codegen/src/lib.rs
+++ b/codegen/src/lib.rs
@@ -67,7 +67,7 @@
 //! ```
 //!
 
-use quote::{quote, quote_spanned};
+use quote::{quote, quote_spanned, ToTokens};
 use syn::{parse::Parser, parse_macro_input, spanned::Spanned};
 
 mod function;
@@ -79,9 +79,20 @@ pub fn export_fn(
     args: proc_macro::TokenStream,
     input: proc_macro::TokenStream,
 ) -> proc_macro::TokenStream {
-    let mut output = proc_macro2::TokenStream::from(input.clone());
+    let output = proc_macro2::TokenStream::from(input.clone());
+
     let parsed_params = parse_macro_input!(args as function::ExportedFnParams);
     let function_def = parse_macro_input!(input as function::ExportedFn);
+
+    let mut output = if let Some(ref rename) = parsed_params.name {
+        // If it wasn't a function, it wouldn't have parsed earlier, so unwrap() is fine.
+        let mut output_fn: syn::ItemFn = syn::parse2(output.clone()).unwrap();
+        let new_name = syn::Ident::new(rename, output_fn.sig.ident.span());
+        output_fn.sig.ident = new_name;
+        output_fn.into_token_stream()
+    } else {
+        output
+    };
     output.extend(function_def.generate_with_params(parsed_params));
     proc_macro::TokenStream::from(output)
 }


### PR DESCRIPTION
Completes the next item on my list.