### PR TITLE
Function names capturing as external variables bug

### DIFF
--- a/src/parser.rs
+++ b/src/parser.rs
@@ -1635,6 +1635,11 @@ fn parse_primary(
         Token::CharConstant(c) => Expr::CharConstant(Box::new((c, settings.pos))),
         Token::StringConstant(s) => Expr::StringConstant(Box::new((s.into(), settings.pos))),
         Token::Identifier(s) => {
+            // prevents capturing of the function call
+            #[cfg(not(feature = "no_closure"))]
+            if *next_token == Token::LeftParen || *next_token == Token::Bang {
+                state.allow_capture = false;
+            }
             let index = state.access_var(&s, settings.pos);
             Expr::Variable(Box::new(((s, settings.pos), None, 0, index)))
         }

--- a/tests/closures.rs
+++ b/tests/closures.rs
@@ -38,7 +38,7 @@ fn test_fn_ptr_curry_call() -> Result<(), Box<EvalAltResult>> {
 #[cfg(not(feature = "no_closure"))]
 #[cfg(not(feature = "no_object"))]
 fn test_closures() -> Result<(), Box<EvalAltResult>> {
-    let engine = Engine::new();
+    let mut engine = Engine::new();
 
     assert_eq!(
         engine.eval::<INT>(
@@ -76,6 +76,23 @@ fn test_closures() -> Result<(), Box<EvalAltResult>> {
             a.is_shared()
         "#
     )?);
+
+    let mut module = Module::new();
+
+    module.set_fn_1("plus_one", |x: INT| Ok(x + 1));
+
+    engine.load_package(module);
+
+    assert_eq!(
+        engine.eval::<INT>(
+            r#"
+                let a = 41;
+                let f = || plus_one(a);
+                f.call()
+            "#
+        )?,
+        42
+    );
 
     Ok(())
 }


### PR DESCRIPTION
Prior to this fix for the following snippet:

```
|| {
  x();
}
```

`x` was interpreted as an external variable for anonymous function.