### PR TITLE
export_fn: add return_raw attribute

### DIFF
--- a/codegen/ui_tests/export_fn_bad_attr.stderr
+++ b/codegen/ui_tests/export_fn_bad_attr.stderr
@@ -1,7 +1,7 @@
 error: unknown attribute 'unknown'
  --> $DIR/export_fn_bad_attr.rs:9:13
   |
-9 | #[export_fn(unknown = true)]
+9 | #[export_fn(unknown = "thing")]
   |             ^^^^^^^
 
 error[E0425]: cannot find function `test_fn` in this scope

--- a/codegen/ui_tests/export_fn_bad_value.stderr
+++ b/codegen/ui_tests/export_fn_bad_value.stderr
@@ -1,4 +1,4 @@
-error: expecting string literal value
+error: expecting string literal
  --> $DIR/export_fn_bad_value.rs:9:20
   |
 9 | #[export_fn(name = true)]

--- a/codegen/ui_tests/export_fn_extra_value.rs
+++ b/codegen/ui_tests/export_fn_extra_value.rs
@@ -6,7 +6,7 @@ struct Point {
     y: f32,
 }
 
-#[export_fn(unknown = "thing")]
+#[export_fn(return_raw = "yes")]
 pub fn test_fn(input: Point) -> bool {
     input.x > input.y
 }

--- a/codegen/ui_tests/export_fn_extra_value.stderr
+++ b/codegen/ui_tests/export_fn_extra_value.stderr
@@ -1,0 +1,11 @@
+error: extraneous value
+ --> $DIR/export_fn_extra_value.rs:9:26
+  |
+9 | #[export_fn(return_raw = "yes")]
+  |                          ^^^^^
+
+error[E0425]: cannot find function `test_fn` in this scope
+  --> $DIR/export_fn_extra_value.rs:19:8
+   |
+19 |     if test_fn(n) {
+   |        ^^^^^^^ not found in this scope

--- a/codegen/ui_tests/export_fn_junk_arg.stderr
+++ b/codegen/ui_tests/export_fn_junk_arg.stderr
@@ -1,4 +1,4 @@
-error: expected assignment expression
+error: expecting identifier
  --> $DIR/export_fn_junk_arg.rs:9:13
   |
 9 | #[export_fn("wheeeee")]

--- a/codegen/ui_tests/export_fn_missing_value.rs
+++ b/codegen/ui_tests/export_fn_missing_value.rs
@@ -6,7 +6,7 @@ struct Point {
     y: f32,
 }
 
-#[export_fn(unknown = "thing")]
+#[export_fn(name)]
 pub fn test_fn(input: Point) -> bool {
     input.x > input.y
 }

--- a/codegen/ui_tests/export_fn_missing_value.stderr
+++ b/codegen/ui_tests/export_fn_missing_value.stderr
@@ -1,0 +1,11 @@
+error: requires value
+ --> $DIR/export_fn_missing_value.rs:9:13
+  |
+9 | #[export_fn(name)]
+  |             ^^^^
+
+error[E0425]: cannot find function `test_fn` in this scope
+  --> $DIR/export_fn_missing_value.rs:19:8
+   |
+19 |     if test_fn(n) {
+   |        ^^^^^^^ not found in this scope

--- a/codegen/ui_tests/export_fn_path_attr.rs
+++ b/codegen/ui_tests/export_fn_path_attr.rs
@@ -6,7 +6,7 @@ struct Point {
     y: f32,
 }
 
-#[export_fn(unknown = "thing")]
+#[export_fn(rhai::name = "thing")]
 pub fn test_fn(input: Point) -> bool {
     input.x > input.y
 }

--- a/codegen/ui_tests/export_fn_path_attr.stderr
+++ b/codegen/ui_tests/export_fn_path_attr.stderr
@@ -1,0 +1,11 @@
+error: expecting attribute name
+ --> $DIR/export_fn_path_attr.rs:9:13
+  |
+9 | #[export_fn(rhai::name = "thing")]
+  |             ^^^^^^^^^^
+
+error[E0425]: cannot find function `test_fn` in this scope
+  --> $DIR/export_fn_path_attr.rs:19:8
+   |
+19 |     if test_fn(n) {
+   |        ^^^^^^^ not found in this scope


### PR DESCRIPTION
This avoids wrapping the output of a function in a `Dynamic`, allowing an `exported_fn` to directly return the Rhai internal error type:

```rust
use rhai::plugin::*;
use rhai::FLOAT;

#[export_fn(return_raw)]
pub fn distance_function(
    x1: FLOAT,
    y1: FLOAT,
    x2: FLOAT,
    y2: FLOAT,
) -> Result<rhai::Dynamic, Box<rhai::EvalAltResult>> {
    Ok(Dynamic::from(
        ((y2 - y1).abs().powf(2.0) + (x2 - x1).abs().powf(2.0)).sqrt(),
    ))
}
```

If you would like to bikeshed the name, feel free.