### PR TITLE
codegen: replace downcast_clone with more efficient mem::take

### DIFF
--- a/codegen/src/function.rs
+++ b/codegen/src/function.rs
@@ -356,16 +356,15 @@ impl ExportedFn {
                             &syn::Type::Path(ref p) if p.path == str_type_path => {
                                 is_str_ref = true;
                                 quote_spanned!(arg_type.span()=>
-                                                   args[#i]
-                                                   .downcast_clone::<ImmutableString>()
-                                                   .unwrap())
+                                                   std::mem::take(args[#i])
+                                                   .clone().cast::<ImmutableString>())
                             }
                             _ => panic!("internal error: why wasn't this found earlier!?"),
                         },
                         _ => {
                             is_str_ref = false;
                             quote_spanned!(arg_type.span()=>
-                                            args[#i].downcast_clone::<#arg_type>().unwrap())
+                                           std::mem::take(args[#i]).clone().cast::<#arg_type>())
                         }
                     };
 
@@ -768,7 +767,7 @@ mod generate_tests {
                                     format!("wrong arg count: {} != {}",
                                             args.len(), 1usize), Position::none())));
                         }
-                        let arg0 = args[0usize].downcast_clone::<usize>().unwrap();
+                        let arg0 = std::mem::take(args[0usize]).clone().cast::<usize>();
                         Ok(Dynamic::from(do_something(arg0)))
                     }
 
@@ -808,7 +807,7 @@ mod generate_tests {
                                 format!("wrong arg count: {} != {}",
                                         args.len(), 1usize), Position::none())));
                     }
-                    let arg0 = args[0usize].downcast_clone::<usize>().unwrap();
+                    let arg0 = std::mem::take(args[0usize]).clone().cast::<usize>();
                     Ok(Dynamic::from(do_something(arg0)))
                 }
 
@@ -845,8 +844,8 @@ mod generate_tests {
                                     format!("wrong arg count: {} != {}",
                                             args.len(), 2usize), Position::none())));
                         }
-                        let arg0 = args[0usize].downcast_clone::<usize>().unwrap();
-                        let arg1 = args[1usize].downcast_clone::<usize>().unwrap();
+                        let arg0 = std::mem::take(args[0usize]).clone().cast::<usize>();
+                        let arg1 = std::mem::take(args[1usize]).clone().cast::<usize>();
                         Ok(Dynamic::from(add_together(arg0, arg1)))
                     }
 
@@ -891,7 +890,7 @@ mod generate_tests {
                                     format!("wrong arg count: {} != {}",
                                             args.len(), 2usize), Position::none())));
                         }
-                        let arg1 = args[1usize].downcast_clone::<usize>().unwrap();
+                        let arg1 = std::mem::take(args[1usize]).clone().cast::<usize>();
                         let arg0: &mut _ = &mut args[0usize].write_lock::<usize>().unwrap();
                         Ok(Dynamic::from(increment(arg0, arg1)))
                     }
@@ -938,7 +937,7 @@ mod generate_tests {
                                     format!("wrong arg count: {} != {}",
                                             args.len(), 1usize), Position::none())));
                         }
-                        let arg0 = args[0usize].downcast_clone::<ImmutableString>().unwrap();
+                        let arg0 = std::mem::take(args[0usize]).clone().cast::<ImmutableString>();
                         Ok(Dynamic::from(special_print(&arg0)))
                     }
 

--- a/codegen/src/module.rs
+++ b/codegen/src/module.rs
@@ -371,7 +371,7 @@ mod generate_tests {
                                     format!("wrong arg count: {} != {}",
                                             args.len(), 1usize), Position::none())));
                         }
-                        let arg0 = args[0usize].downcast_clone::<INT>().unwrap();
+                        let arg0 = std::mem::take(args[0usize]).clone().cast::<INT>();
                         Ok(Dynamic::from(add_one_to(arg0)))
                     }
 
@@ -433,8 +433,8 @@ mod generate_tests {
                                     format!("wrong arg count: {} != {}",
                                             args.len(), 2usize), Position::none())));
                         }
-                        let arg0 = args[0usize].downcast_clone::<INT>().unwrap();
-                        let arg1 = args[1usize].downcast_clone::<INT>().unwrap();
+                        let arg0 = std::mem::take(args[0usize]).clone().cast::<INT>();
+                        let arg1 = std::mem::take(args[1usize]).clone().cast::<INT>();
                         Ok(Dynamic::from(add_together(arg0, arg1)))
                     }
 
@@ -605,7 +605,7 @@ mod generate_tests {
                                     format!("wrong arg count: {} != {}",
                                             args.len(), 1usize), Position::none())));
                         }
-                        let arg0 = args[0usize].downcast_clone::<ImmutableString>().unwrap();
+                        let arg0 = std::mem::take(args[0usize]).clone().cast::<ImmutableString>();
                         Ok(Dynamic::from(print_out_to(&arg0)))
                     }
 

--- a/src/any.rs
+++ b/src/any.rs
@@ -1082,13 +1082,6 @@ impl Dynamic {
         }
     }
 
-    /// Copy and return a `Dynamic` if it contains a type that can be trivially copied.
-    /// Returns `None` if the cast fails.
-    #[inline(always)]
-    pub fn downcast_clone<T: Variant + Clone>(&self) -> Option<T> {
-        self.downcast_ref::<T>().map(|t| t.clone())
-    }
-
     /// Cast the `Dynamic` as the system integer type `INT` and return it.
     /// Returns the name of the actual type if the cast fails.
     #[inline(always)]

--- a/src/fn_register.rs
+++ b/src/fn_register.rs
@@ -47,10 +47,10 @@ pub trait RegisterPlugin<PL: crate::plugin::Plugin> {
     ///     fn is_varadic(&self) -> bool { false }
     ///
     ///     fn call(&self, args: &mut[&mut Dynamic], pos: Position) -> Result<Dynamic, Box<EvalAltResult>> {
-    ///         let x1: NUMBER = args[0].downcast_clone::<NUMBER>().unwrap();
-    ///         let y1: NUMBER = args[1].downcast_clone::<NUMBER>().unwrap();
-    ///         let x2: NUMBER = args[2].downcast_clone::<NUMBER>().unwrap();
-    ///         let y2: NUMBER = args[3].downcast_clone::<NUMBER>().unwrap();
+    ///         let x1: NUMBER = std::mem::take(args[0]).clone().cast::<NUMBER>();
+    ///         let y1: NUMBER = std::mem::take(args[1]).clone().cast::<NUMBER>();
+    ///         let x2: NUMBER = std::mem::take(args[2]).clone().cast::<NUMBER>();
+    ///         let y2: NUMBER = std::mem::take(args[3]).clone().cast::<NUMBER>();
     /// #       #[cfg(not(feature = "no_float"))]
     ///         let square_sum = (y2 - y1).abs().powf(2.0) + (x2 -x1).abs().powf(2.0);
     /// #       #[cfg(feature = "no_float")]


### PR DESCRIPTION
In fact, this PR removes the `Dynamic::downcast_clone` method entirely.

I wrote it just for my macro code, and (based on other recent API changes) it seems to add little value.