### PR TITLE
Split function register macro, add Engine register support

### DIFF
--- a/codegen/src/register.rs
+++ b/codegen/src/register.rs
@@ -1,0 +1,49 @@
+use quote::{quote, quote_spanned};
+use syn::{parse::Parser, spanned::Spanned};
+
+pub(crate) fn generated_module_path(
+    fn_path: &syn::Path,
+) -> syn::punctuated::Punctuated<syn::PathSegment, syn::Token![::]> {
+    let mut g = fn_path.clone().segments;
+    g.pop();
+    let ident = syn::Ident::new(
+        &format!("rhai_fn_{}", fn_path.segments.last().unwrap().ident),
+        fn_path.span(),
+    );
+    g.push_value(syn::PathSegment {
+        ident,
+        arguments: syn::PathArguments::None,
+    });
+    g
+}
+
+type RegisterMacroInput = (syn::Expr, proc_macro2::TokenStream, syn::Path);
+pub fn parse_register_macro(
+    args: proc_macro::TokenStream,
+) -> Result<RegisterMacroInput, syn::Error> {
+    let parser = syn::punctuated::Punctuated::<syn::Expr, syn::Token![,]>::parse_separated_nonempty;
+    let args = parser.parse(args).unwrap();
+    let arg_span = args.span();
+    let mut items: Vec<syn::Expr> = args.into_iter().collect();
+    if items.len() != 3 {
+        return Err(syn::Error::new(
+            arg_span,
+            "this macro requires three arguments",
+        ));
+    }
+    let export_name = match &items[1] {
+        syn::Expr::Lit(litstr) => quote_spanned!(items[1].span()=>
+                                                 #litstr.to_string()),
+        expr => quote! { #expr },
+    };
+    let rust_modpath = if let syn::Expr::Path(ref path) = &items[2] {
+        path.path.clone()
+    } else {
+        return Err(syn::Error::new(
+            items[2].span(),
+            "third argument must be a function name",
+        ));
+    };
+    let module = items.remove(0);
+    Ok((module, export_name, rust_modpath))
+}

--- a/codegen/tests/test_functions.rs
+++ b/codegen/tests/test_functions.rs
@@ -16,7 +16,7 @@ fn raw_fn_test() -> Result<(), Box<EvalAltResult>> {
     let mut engine = Engine::new();
     engine.register_fn("get_mystic_number", || 42 as FLOAT);
     let mut m = Module::new();
-    rhai::register_exported_fn!(
+    rhai::set_exported_fn!(
         m,
         "euclidean_distance".to_string(),
         raw_fn::distance_function
@@ -50,7 +50,7 @@ fn raw_fn_mut_test() -> Result<(), Box<EvalAltResult>> {
     let mut engine = Engine::new();
     engine.register_fn("get_mystic_number", || 42 as FLOAT);
     let mut m = Module::new();
-    rhai::register_exported_fn!(m, "add_in_place", raw_fn_mut::add_in_place);
+    rhai::set_exported_fn!(m, "add_in_place", raw_fn_mut::add_in_place);
     let mut r = StaticModuleResolver::new();
     r.insert("Math::Advanced".to_string(), m);
     engine.set_module_resolver(Some(r));
@@ -82,7 +82,7 @@ fn raw_fn_str_test() -> Result<(), Box<EvalAltResult>> {
     let mut engine = Engine::new();
     engine.register_fn("get_mystic_number", || 42 as FLOAT);
     let mut m = Module::new();
-    rhai::register_exported_fn!(m, "write_out_str", raw_fn_str::write_out_str);
+    rhai::set_exported_fn!(m, "write_out_str", raw_fn_str::write_out_str);
     let mut r = StaticModuleResolver::new();
     r.insert("Host::IO".to_string(), m);
     engine.set_module_resolver(Some(r));
@@ -138,9 +138,9 @@ mod mut_opaque_ref {
 fn mut_opaque_ref_test() -> Result<(), Box<EvalAltResult>> {
     let mut engine = Engine::new();
     let mut m = Module::new();
-    rhai::register_exported_fn!(m, "new_message", mut_opaque_ref::new_message);
-    rhai::register_exported_fn!(m, "new_os_message", mut_opaque_ref::new_os_message);
-    rhai::register_exported_fn!(m, "write_out_message", mut_opaque_ref::write_out_message);
+    rhai::set_exported_fn!(m, "new_message", mut_opaque_ref::new_message);
+    rhai::set_exported_fn!(m, "new_os_message", mut_opaque_ref::new_os_message);
+    rhai::set_exported_fn!(m, "write_out_message", mut_opaque_ref::write_out_message);
     let mut r = StaticModuleResolver::new();
     r.insert("Host::Msg".to_string(), m);
     engine.set_module_resolver(Some(r));
@@ -174,7 +174,7 @@ fn rename_fn_test() -> Result<(), Box<EvalAltResult>> {
     let mut engine = Engine::new();
     engine.register_fn("get_mystic_number", || 42 as FLOAT);
     let mut m = Module::new();
-    rhai::register_exported_fn!(m, "add_two_floats", rename_fn::add_float);
+    rhai::set_exported_fn!(m, "add_two_floats", rename_fn::add_float);
     let mut r = StaticModuleResolver::new();
     r.insert("Math::Advanced".to_string(), m);
     engine.set_module_resolver(Some(r));
@@ -211,8 +211,8 @@ fn duplicate_fn_rename_test() -> Result<(), Box<EvalAltResult>> {
     let mut engine = Engine::new();
     engine.register_fn("get_mystic_number", || 42 as FLOAT);
     let mut m = Module::new();
-    rhai::register_exported_fn!(m, "add_two_floats", duplicate_fn_rename::add_float);
-    rhai::register_exported_fn!(m, "add_two_ints", duplicate_fn_rename::add_int);
+    rhai::set_exported_fn!(m, "add_two_floats", duplicate_fn_rename::add_float);
+    rhai::set_exported_fn!(m, "add_two_ints", duplicate_fn_rename::add_int);
     let mut r = StaticModuleResolver::new();
     r.insert("Math::Advanced".to_string(), m);
     engine.set_module_resolver(Some(r));
@@ -224,7 +224,7 @@ fn duplicate_fn_rename_test() -> Result<(), Box<EvalAltResult>> {
        let ix = 42;
        let iy = math::add_two_ints(ix, 1);
        [fy, iy]
-       "#
+       "#,
     )?;
     assert_eq!(&output_array[0].as_float().unwrap(), &43.0);
     assert_eq!(&output_array[1].as_int().unwrap(), &43);
@@ -253,7 +253,7 @@ fn raw_returning_fn_test() -> Result<(), Box<EvalAltResult>> {
     let mut engine = Engine::new();
     engine.register_fn("get_mystic_number", || 42 as FLOAT);
     let mut m = Module::new();
-    rhai::register_exported_fn!(
+    rhai::set_exported_fn!(
         m,
         "euclidean_distance".to_string(),
         raw_returning_fn::distance_function

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -70,10 +70,7 @@ mod module;
 mod optimize;
 pub mod packages;
 mod parser;
-#[cfg(not(feature = "no_module"))]
 pub mod plugin;
-#[cfg(feature = "no_module")]
-mod plugin;
 mod result;
 mod scope;
 #[cfg(feature = "serde")]

--- a/src/plugin.rs
+++ b/src/plugin.rs
@@ -11,6 +11,7 @@ pub use crate::{
     ImmutableString,
     Module,
     Position,
+    RegisterResultFn,
 };
 
 pub use rhai_codegen::*;

--- a/src/plugin.rs
+++ b/src/plugin.rs
@@ -14,6 +14,9 @@ pub use crate::{
     RegisterResultFn,
 };
 
+#[cfg(features = "no_module")]
+pub use rhai_codegen::{export_fn, register_exported_fn};
+#[cfg(not(features = "no_module"))]
 pub use rhai_codegen::*;
 
 #[cfg(features = "sync")]

--- a/tests/macro_register.rs
+++ b/tests/macro_register.rs
@@ -1,0 +1,17 @@
+use rhai::plugin::*;
+use rhai::{Engine, EvalAltResult, INT};
+
+
+#[export_fn]
+pub fn add_together(x: INT, y: INT) -> INT {
+    x + y
+}
+
+#[test]
+fn test_exported_fn_register() -> Result<(), Box<EvalAltResult>> {
+    let mut engine = Engine::new();
+    register_exported_fn!(engine, "add_two", add_together);
+    assert_eq!(engine.eval::<INT>("let a = 1; add_two(a, 41)")?, 42);
+
+    Ok(())
+}

--- a/tests/macro_unroll.rs
+++ b/tests/macro_unroll.rs
@@ -33,9 +33,9 @@ macro_rules! register_in_bulk {
         $(
             {
                 let type_str = stringify!($type_names);
-                register_exported_fn!($mod_name,
-                                      format!(concat!(stringify!($op_name), "_{}"), type_str),
-                                      crate::$op_name::$type_names::op);
+                set_exported_fn!($mod_name,
+                                 format!(concat!(stringify!($op_name), "_{}"), type_str),
+                                 crate::$op_name::$type_names::op);
             }
         )*
     }

--- a/tests/plugins.rs
+++ b/tests/plugins.rs
@@ -22,7 +22,7 @@ fn test_plugins_package() -> Result<(), Box<EvalAltResult>> {
     let mut engine = Engine::new();
 
     let mut m = exported_module!(special_array_package);
-    register_exported_fn!(m, "greet", make_greeting);
+    set_exported_fn!(m, "greet", make_greeting);
 
     engine.load_package(m);
 


### PR DESCRIPTION
Note that this renames what used to be called `register_exported_fn!` to `set_exported_fn!`. The old name is used by the separate new macro for engines.

This is designed to match their methods: `engine.register_fn` and `module.set_fn`.

I also expect the CI to fail on `no_std`, since I put in a doc test for both. Let's see what happens...