### PR TITLE
Convert args length check to debug assert

### DIFF
--- a/codegen/src/function.rs
+++ b/codegen/src/function.rs
@@ -485,11 +485,9 @@ impl ExportedFn {
                 fn call(&self,
                         args: &mut [&mut Dynamic], pos: Position
                 ) -> Result<Dynamic, Box<EvalAltResult>> {
-                    if args.len() != #arg_count {
-                        return Err(Box::new(EvalAltResult::ErrorRuntime(
-                                format!("wrong arg count: {} != {}",
-                                        args.len(), #arg_count), Position::none())));
-                    }
+                    debug_assert_eq!(args.len(), #arg_count,
+                                     "wrong arg count: {} != {}",
+                                     args.len(), #arg_count);
                     #(#unpack_stmts)*
                     #return_expr
                 }
@@ -778,11 +776,8 @@ mod generate_tests {
                     fn call(&self,
                             args: &mut [&mut Dynamic], pos: Position
                     ) -> Result<Dynamic, Box<EvalAltResult>> {
-                        if args.len() != 0usize {
-                            return Err(Box::new(EvalAltResult::ErrorRuntime(
-                                    format!("wrong arg count: {} != {}",
-                                            args.len(), 0usize), Position::none())));
-                        }
+                        debug_assert_eq!(args.len(), 0usize,
+                                         "wrong arg count: {} != {}", args.len(), 0usize);
                         Ok(Dynamic::from(do_nothing()))
                     }
 
@@ -825,11 +820,8 @@ mod generate_tests {
                     fn call(&self,
                             args: &mut [&mut Dynamic], pos: Position
                     ) -> Result<Dynamic, Box<EvalAltResult>> {
-                        if args.len() != 1usize {
-                            return Err(Box::new(EvalAltResult::ErrorRuntime(
-                                    format!("wrong arg count: {} != {}",
-                                            args.len(), 1usize), Position::none())));
-                        }
+                        debug_assert_eq!(args.len(), 1usize,
+                                    "wrong arg count: {} != {}", args.len(), 1usize);
                         let arg0 = mem::take(args[0usize]).clone().cast::<usize>();
                         Ok(Dynamic::from(do_something(arg0)))
                     }
@@ -869,11 +861,8 @@ mod generate_tests {
                 fn call(&self,
                         args: &mut [&mut Dynamic], pos: Position
                 ) -> Result<Dynamic, Box<EvalAltResult>> {
-                    if args.len() != 1usize {
-                        return Err(Box::new(EvalAltResult::ErrorRuntime(
-                                format!("wrong arg count: {} != {}",
-                                        args.len(), 1usize), Position::none())));
-                    }
+                    debug_assert_eq!(args.len(), 1usize,
+                                "wrong arg count: {} != {}", args.len(), 1usize);
                     let arg0 = mem::take(args[0usize]).clone().cast::<usize>();
                     Ok(Dynamic::from(do_something(arg0)))
                 }
@@ -906,11 +895,8 @@ mod generate_tests {
                     fn call(&self,
                             args: &mut [&mut Dynamic], pos: Position
                     ) -> Result<Dynamic, Box<EvalAltResult>> {
-                        if args.len() != 2usize {
-                            return Err(Box::new(EvalAltResult::ErrorRuntime(
-                                    format!("wrong arg count: {} != {}",
-                                            args.len(), 2usize), Position::none())));
-                        }
+                        debug_assert_eq!(args.len(), 2usize,
+                                    "wrong arg count: {} != {}", args.len(), 2usize);
                         let arg0 = mem::take(args[0usize]).clone().cast::<usize>();
                         let arg1 = mem::take(args[1usize]).clone().cast::<usize>();
                         Ok(Dynamic::from(add_together(arg0, arg1)))
@@ -956,11 +942,8 @@ mod generate_tests {
                     fn call(&self,
                             args: &mut [&mut Dynamic], pos: Position
                     ) -> Result<Dynamic, Box<EvalAltResult>> {
-                        if args.len() != 2usize {
-                            return Err(Box::new(EvalAltResult::ErrorRuntime(
-                                    format!("wrong arg count: {} != {}",
-                                            args.len(), 2usize), Position::none())));
-                        }
+                        debug_assert_eq!(args.len(), 2usize,
+                                    "wrong arg count: {} != {}", args.len(), 2usize);
                         let arg1 = mem::take(args[1usize]).clone().cast::<usize>();
                         let arg0: &mut _ = &mut args[0usize].write_lock::<usize>().unwrap();
                         Ok(Dynamic::from(increment(arg0, arg1)))
@@ -1007,11 +990,8 @@ mod generate_tests {
                     fn call(&self,
                             args: &mut [&mut Dynamic], pos: Position
                     ) -> Result<Dynamic, Box<EvalAltResult>> {
-                        if args.len() != 1usize {
-                            return Err(Box::new(EvalAltResult::ErrorRuntime(
-                                    format!("wrong arg count: {} != {}",
-                                            args.len(), 1usize), Position::none())));
-                        }
+                        debug_assert_eq!(args.len(), 1usize,
+                                    "wrong arg count: {} != {}", args.len(), 1usize);
                         let arg0 = mem::take(args[0usize]).clone().cast::<ImmutableString>();
                         Ok(Dynamic::from(special_print(&arg0)))
                     }

--- a/codegen/src/module.rs
+++ b/codegen/src/module.rs
@@ -314,11 +314,8 @@ mod generate_tests {
                     fn call(&self,
                             args: &mut [&mut Dynamic], pos: Position
                     ) -> Result<Dynamic, Box<EvalAltResult>> {
-                        if args.len() != 0usize {
-                            return Err(Box::new(EvalAltResult::ErrorRuntime(
-                                    format!("wrong arg count: {} != {}",
-                                            args.len(), 0usize), Position::none())));
-                        }
+                        debug_assert_eq!(args.len(), 0usize,
+                                            "wrong arg count: {} != {}", args.len(), 0usize);
                         Ok(Dynamic::from(get_mystic_number()))
                     }
 
@@ -374,11 +371,8 @@ mod generate_tests {
                     fn call(&self,
                             args: &mut [&mut Dynamic], pos: Position
                     ) -> Result<Dynamic, Box<EvalAltResult>> {
-                        if args.len() != 1usize {
-                            return Err(Box::new(EvalAltResult::ErrorRuntime(
-                                    format!("wrong arg count: {} != {}",
-                                            args.len(), 1usize), Position::none())));
-                        }
+                        debug_assert_eq!(args.len(), 1usize,
+                                            "wrong arg count: {} != {}", args.len(), 1usize);
                         let arg0 = mem::take(args[0usize]).clone().cast::<INT>();
                         Ok(Dynamic::from(add_one_to(arg0)))
                     }
@@ -436,11 +430,8 @@ mod generate_tests {
                     fn call(&self,
                             args: &mut [&mut Dynamic], pos: Position
                     ) -> Result<Dynamic, Box<EvalAltResult>> {
-                        if args.len() != 2usize {
-                            return Err(Box::new(EvalAltResult::ErrorRuntime(
-                                    format!("wrong arg count: {} != {}",
-                                            args.len(), 2usize), Position::none())));
-                        }
+                        debug_assert_eq!(args.len(), 2usize,
+                                            "wrong arg count: {} != {}", args.len(), 2usize);
                         let arg0 = mem::take(args[0usize]).clone().cast::<INT>();
                         let arg1 = mem::take(args[1usize]).clone().cast::<INT>();
                         Ok(Dynamic::from(add_together(arg0, arg1)))
@@ -608,11 +599,8 @@ mod generate_tests {
                     fn call(&self,
                             args: &mut [&mut Dynamic], pos: Position
                     ) -> Result<Dynamic, Box<EvalAltResult>> {
-                        if args.len() != 1usize {
-                            return Err(Box::new(EvalAltResult::ErrorRuntime(
-                                    format!("wrong arg count: {} != {}",
-                                            args.len(), 1usize), Position::none())));
-                        }
+                        debug_assert_eq!(args.len(), 1usize,
+                                            "wrong arg count: {} != {}", args.len(), 1usize);
                         let arg0 = mem::take(args[0usize]).clone().cast::<ImmutableString>();
                         Ok(Dynamic::from(print_out_to(&arg0)))
                     }
@@ -670,11 +658,8 @@ mod generate_tests {
                     fn call(&self,
                             args: &mut [&mut Dynamic], pos: Position
                     ) -> Result<Dynamic, Box<EvalAltResult>> {
-                        if args.len() != 1usize {
-                            return Err(Box::new(EvalAltResult::ErrorRuntime(
-                                    format!("wrong arg count: {} != {}",
-                                            args.len(), 1usize), Position::none())));
-                        }
+                        debug_assert_eq!(args.len(), 1usize,
+                                            "wrong arg count: {} != {}", args.len(), 1usize);
                         let arg0: &mut _ = &mut args[0usize].write_lock::<FLOAT>().unwrap();
                         Ok(Dynamic::from(increment(arg0)))
                     }


### PR DESCRIPTION
The optimization @schungx has been waiting for! :tada: 

I didn't eliminate it completely, because my experience tells me it will make some nasty bugs very difficult to catch. For example, when (in the distant future) I implement support for variadic functions.