### PR TITLE
Add rhai_fn nested attribute and skip fn parameter

### DIFF
--- a/codegen/tests/test_nested.rs
+++ b/codegen/tests/test_nested.rs
@@ -1,0 +1,36 @@
+use rhai::module_resolvers::*;
+use rhai::{Engine, EvalAltResult, RegisterFn, FLOAT, INT};
+
+pub mod one_fn_module_nested_attr {
+    use rhai::plugin::*;
+
+    #[export_module]
+    pub mod advanced_math {
+        use rhai::plugin::*;
+        use rhai::FLOAT;
+
+        #[rhai_fn(return_raw)]
+        pub fn get_mystic_number() -> Result<Dynamic, Box<EvalAltResult>> {
+            Ok(Dynamic::from(42.0 as FLOAT))
+        }
+    }
+}
+
+#[test]
+fn one_fn_module_nested_attr_test() -> Result<(), Box<EvalAltResult>> {
+    let mut engine = Engine::new();
+    let m = rhai::exported_module!(crate::one_fn_module_nested_attr::advanced_math);
+    let mut r = StaticModuleResolver::new();
+    r.insert("Math::Advanced".to_string(), m);
+    engine.set_module_resolver(Some(r));
+
+    assert_eq!(
+        engine.eval::<FLOAT>(
+            r#"import "Math::Advanced" as math;
+           let m = math::get_mystic_number();
+           m"#
+        )?,
+        42.0
+    );
+    Ok(())
+}

--- a/codegen/ui_tests/rhai_fn_bad_attr.rs
+++ b/codegen/ui_tests/rhai_fn_bad_attr.rs
@@ -1,0 +1,27 @@
+use rhai::plugin::*;
+
+#[derive(Clone)]
+struct Point {
+    x: f32,
+    y: f32,
+}
+
+#[export_module]
+pub mod test_module {
+#[rhai_fn(unknown = "thing")]
+pub fn test_fn(input: Point) -> bool {
+    input.x > input.y
+}
+}
+
+fn main() {
+    let n = Point {
+        x: 0.0,
+        y: 10.0,
+    };
+    if test_module::test_fn(n) {
+        println!("yes");
+    } else {
+        println!("no");
+    }
+}

--- a/codegen/ui_tests/rhai_fn_bad_attr.stderr
+++ b/codegen/ui_tests/rhai_fn_bad_attr.stderr
@@ -1,0 +1,11 @@
+error: unknown attribute 'unknown'
+  --> $DIR/rhai_fn_bad_attr.rs:11:11
+   |
+11 | #[rhai_fn(unknown = "thing")]
+   |           ^^^^^^^
+
+error[E0433]: failed to resolve: use of undeclared type or module `test_module`
+  --> $DIR/rhai_fn_bad_attr.rs:22:8
+   |
+22 |     if test_module::test_fn(n) {
+   |        ^^^^^^^^^^^ use of undeclared type or module `test_module`

--- a/codegen/ui_tests/rhai_fn_bad_value.rs
+++ b/codegen/ui_tests/rhai_fn_bad_value.rs
@@ -1,0 +1,27 @@
+use rhai::plugin::*;
+
+#[derive(Clone)]
+struct Point {
+    x: f32,
+    y: f32,
+}
+
+#[export_module]
+pub mod test_module {
+#[rhai_fn(name = true)]
+pub fn test_fn(input: Point) -> bool {
+    input.x > input.y
+}
+}
+
+fn main() {
+    let n = Point {
+        x: 0.0,
+        y: 10.0,
+    };
+    if test_module::test_fn(n) {
+        println!("yes");
+    } else {
+        println!("no");
+    }
+}

--- a/codegen/ui_tests/rhai_fn_bad_value.stderr
+++ b/codegen/ui_tests/rhai_fn_bad_value.stderr
@@ -1,0 +1,11 @@
+error: expecting string literal
+  --> $DIR/rhai_fn_bad_value.rs:11:18
+   |
+11 | #[rhai_fn(name = true)]
+   |                  ^^^^
+
+error[E0433]: failed to resolve: use of undeclared type or module `test_module`
+  --> $DIR/rhai_fn_bad_value.rs:22:8
+   |
+22 |     if test_module::test_fn(n) {
+   |        ^^^^^^^^^^^ use of undeclared type or module `test_module`

--- a/codegen/ui_tests/rhai_fn_extra_value.rs
+++ b/codegen/ui_tests/rhai_fn_extra_value.rs
@@ -1,0 +1,27 @@
+use rhai::plugin::*;
+
+#[derive(Clone)]
+struct Point {
+    x: f32,
+    y: f32,
+}
+
+#[export_module]
+pub mod test_module {
+#[rhai_fn(return_raw = "yes")]
+pub fn test_fn(input: Point) -> bool {
+    input.x > input.y
+}
+}
+
+fn main() {
+    let n = Point {
+        x: 0.0,
+        y: 10.0,
+    };
+    if test_module::test_fn(n) {
+        println!("yes");
+    } else {
+        println!("no");
+    }
+}

--- a/codegen/ui_tests/rhai_fn_extra_value.stderr
+++ b/codegen/ui_tests/rhai_fn_extra_value.stderr
@@ -1,0 +1,11 @@
+error: extraneous value
+  --> $DIR/rhai_fn_extra_value.rs:11:24
+   |
+11 | #[rhai_fn(return_raw = "yes")]
+   |                        ^^^^^
+
+error[E0433]: failed to resolve: use of undeclared type or module `test_module`
+  --> $DIR/rhai_fn_extra_value.rs:22:8
+   |
+22 |     if test_module::test_fn(n) {
+   |        ^^^^^^^^^^^ use of undeclared type or module `test_module`

--- a/codegen/ui_tests/rhai_fn_junk_arg.rs
+++ b/codegen/ui_tests/rhai_fn_junk_arg.rs
@@ -1,0 +1,27 @@
+use rhai::plugin::*;
+
+#[derive(Clone)]
+struct Point {
+    x: f32,
+    y: f32,
+}
+
+#[export_module]
+pub mod test_module {
+#[rhai_fn("wheeeee")]
+pub fn test_fn(input: Point) -> bool {
+    input.x > input.y
+}
+}
+
+fn main() {
+    let n = Point {
+        x: 0.0,
+        y: 10.0,
+    };
+    if test_module::test_fn(n) {
+        println!("yes");
+    } else {
+        println!("no");
+    }
+}

--- a/codegen/ui_tests/rhai_fn_junk_arg.stderr
+++ b/codegen/ui_tests/rhai_fn_junk_arg.stderr
@@ -1,0 +1,11 @@
+error: expecting identifier
+  --> $DIR/rhai_fn_junk_arg.rs:11:11
+   |
+11 | #[rhai_fn("wheeeee")]
+   |           ^^^^^^^^^
+
+error[E0433]: failed to resolve: use of undeclared type or module `test_module`
+  --> $DIR/rhai_fn_junk_arg.rs:22:8
+   |
+22 |     if test_module::test_fn(n) {
+   |        ^^^^^^^^^^^ use of undeclared type or module `test_module`

--- a/codegen/ui_tests/rhai_fn_missing_value.rs
+++ b/codegen/ui_tests/rhai_fn_missing_value.rs
@@ -1,0 +1,27 @@
+use rhai::plugin::*;
+
+#[derive(Clone)]
+struct Point {
+    x: f32,
+    y: f32,
+}
+
+#[export_module]
+pub mod test_module {
+#[rhai_fn(name)]
+pub fn test_fn(input: Point) -> bool {
+    input.x > input.y
+}
+}
+
+fn main() {
+    let n = Point {
+        x: 0.0,
+        y: 10.0,
+    };
+    if test_module::test_fn(n) {
+        println!("yes");
+    } else {
+        println!("no");
+    }
+}

--- a/codegen/ui_tests/rhai_fn_missing_value.stderr
+++ b/codegen/ui_tests/rhai_fn_missing_value.stderr
@@ -1,0 +1,11 @@
+error: requires value
+  --> $DIR/rhai_fn_missing_value.rs:11:11
+   |
+11 | #[rhai_fn(name)]
+   |           ^^^^
+
+error[E0433]: failed to resolve: use of undeclared type or module `test_module`
+  --> $DIR/rhai_fn_missing_value.rs:22:8
+   |
+22 |     if test_module::test_fn(n) {
+   |        ^^^^^^^^^^^ use of undeclared type or module `test_module`

--- a/codegen/ui_tests/rhai_fn_path_attr.rs
+++ b/codegen/ui_tests/rhai_fn_path_attr.rs
@@ -1,0 +1,27 @@
+use rhai::plugin::*;
+
+#[derive(Clone)]
+struct Point {
+    x: f32,
+    y: f32,
+}
+
+#[export_module]
+pub mod test_module {
+#[rhai_fn(rhai::name = "thing")]
+pub fn test_fn(input: Point) -> bool {
+    input.x > input.y
+}
+}
+
+fn main() {
+    let n = Point {
+        x: 0.0,
+        y: 10.0,
+    };
+    if test_module::test_fn(n) {
+        println!("yes");
+    } else {
+        println!("no");
+    }
+}

--- a/codegen/ui_tests/rhai_fn_path_attr.stderr
+++ b/codegen/ui_tests/rhai_fn_path_attr.stderr
@@ -1,0 +1,11 @@
+error: expecting attribute name
+  --> $DIR/rhai_fn_path_attr.rs:11:11
+   |
+11 | #[rhai_fn(rhai::name = "thing")]
+   |           ^^^^^^^^^^
+
+error[E0433]: failed to resolve: use of undeclared type or module `test_module`
+  --> $DIR/rhai_fn_path_attr.rs:22:8
+   |
+22 |     if test_module::test_fn(n) {
+   |        ^^^^^^^^^^^ use of undeclared type or module `test_module`


### PR DESCRIPTION
This pull request adds two things that are related.

First and foremost, it adds the `rhai_fn` attribute, which accepts the same parameters as `export_fn`, but operates within an exported module. For example:

```rust
#[export_module]
pub mod advanced_math {
    use rhai::plugin::*;
    use rhai::FLOAT;

    #[rhai_fn(return_raw)]
    pub fn get_mystic_number() -> Result<Dynamic, Box<EvalAltResult>> {
        Ok(Dynamic::from(42.0 as FLOAT))
    }
}
```

Second, it adds the ability to skip a function within a module that would otherwise be exported to Rhai.

For example, consider this code:

```rust
pub mod one_fn {
    #[rhai_fn(skip)]
    pub fn get_mystic_number() -> INT {
        42
    }
}
```

Without the attribute, it would be included in the Rhai module because it is marked as public. Because of the `skip` parameter on the attribute, instead the macro will skip it, resulting in this code being generated:

```rust
pub mod one_fn {
    pub fn get_mystic_number() -> INT {
        42
    }
    #[allow(unused_imports)]
    use super::*;
    #[allow(unused_mut)]
    pub fn rhai_module_generate() -> Module {
        let mut m = Module::new();
        m
    }
}
```

This is the beginning of a separate system of attributes to declare what is exported to Rhai, explicitly and completely independently of the function's declaration in Rust. I will do more work on that in separate PRs.