### PR TITLE
codegen: rhai_fn test improvements and name restrictions

### DIFF
--- a/codegen/src/function.rs
+++ b/codegen/src/function.rs
@@ -18,6 +18,7 @@ pub(crate) struct ExportedFnParams {
     pub name: Option<String>,
     pub return_raw: bool,
     pub skip: bool,
+    pub span: Option<proc_macro2::Span>,
 }
 
 impl ExportedFnParams {
@@ -47,6 +48,7 @@ impl Parse for ExportedFnParams {
         let arg_list = args.call(
             syn::punctuated::Punctuated::<syn::Expr, syn::Token![,]>::parse_separated_nonempty,
         )?;
+        let span = arg_list.span();
 
         let mut attrs: HashMap<proc_macro2::Ident, Option<syn::LitStr>> = HashMap::new();
         for arg in arg_list {
@@ -125,6 +127,7 @@ impl Parse for ExportedFnParams {
             name,
             return_raw,
             skip,
+            span: Some(span),
             ..Default::default()
         })
     }

--- a/codegen/src/function.rs
+++ b/codegen/src/function.rs
@@ -113,6 +113,14 @@ impl Parse for ExportedFnParams {
             }
         }
 
+        // Check validity of name, if present.
+        if name.as_ref().filter(|n| n.contains('.')).is_some() {
+            return Err(syn::Error::new(
+                span,
+                "Rhai function names may not contain dot"
+            ))
+        }
+
         Ok(ExportedFnParams {
             name,
             return_raw,

--- a/codegen/tests/test_functions.rs
+++ b/codegen/tests/test_functions.rs
@@ -1,6 +1,6 @@
 use rhai::module_resolvers::*;
 use rhai::plugin::*;
-use rhai::{Array, Engine, EvalAltResult, Module, RegisterFn, FLOAT};
+use rhai::{Engine, EvalAltResult, Module, RegisterFn, FLOAT};
 
 pub mod raw_fn {
     use rhai::plugin::*;

--- a/codegen/tests/test_modules.rs
+++ b/codegen/tests/test_modules.rs
@@ -187,12 +187,12 @@ mod duplicate_fn_rename {
     pub mod my_adds {
         use rhai::{FLOAT, INT};
 
-        #[rhai_fn(name = "add_f")]
+        #[rhai_fn(name = "add")]
         pub fn add_float(f1: FLOAT, f2: FLOAT) -> FLOAT {
             f1 + f2
         }
 
-        #[rhai_fn(name = "add_i")]
+        #[rhai_fn(name = "add")]
         pub fn add_int(i1: INT, i2: INT) -> INT {
             i1 + i2
         }
@@ -211,9 +211,9 @@ fn duplicate_fn_rename_test() -> Result<(), Box<EvalAltResult>> {
     let output_array = engine.eval::<Array>(
         r#"import "Math::Advanced" as math;
        let fx = get_mystic_number();
-       let fy = math::add_f(fx, 1.0);
+       let fy = math::add(fx, 1.0);
        let ix = 42;
-       let iy = math::add_i(ix, 1);
+       let iy = math::add(ix, 1);
        [fy, iy]
        "#,
     )?;

--- a/codegen/ui_tests/rhai_fn_rename_collision.rs
+++ b/codegen/ui_tests/rhai_fn_rename_collision.rs
@@ -1,0 +1,33 @@
+use rhai::plugin::*;
+
+#[derive(Clone)]
+pub struct Point {
+    x: f32,
+    y: f32,
+}
+
+#[export_module]
+pub mod test_module {
+    pub use super::Point;
+    #[rhai_fn(name = "foo")]
+    pub fn test_fn(input: Point) -> bool {
+        input.x > input.y
+    }
+
+    #[rhai_fn(name = "foo")]
+    pub fn test_fn_2(input: Point) -> bool {
+        input.x < input.y
+    }
+}
+
+fn main() {
+    let n = Point {
+        x: 0.0,
+        y: 10.0,
+    };
+    if test_module::test_fn(n) {
+        println!("yes");
+    } else {
+        println!("no");
+    }
+}

--- a/codegen/ui_tests/rhai_fn_rename_collision.stderr
+++ b/codegen/ui_tests/rhai_fn_rename_collision.stderr
@@ -1,0 +1,17 @@
+error: duplicate Rhai signature for 'foo'
+  --> $DIR/rhai_fn_rename_collision.rs:17:15
+   |
+17 |     #[rhai_fn(name = "foo")]
+   |               ^^^^^^^^^^^^
+
+error: duplicated function renamed 'foo'
+  --> $DIR/rhai_fn_rename_collision.rs:12:15
+   |
+12 |     #[rhai_fn(name = "foo")]
+   |               ^^^^^^^^^^^^
+
+error[E0433]: failed to resolve: use of undeclared type or module `test_module`
+  --> $DIR/rhai_fn_rename_collision.rs:28:8
+   |
+28 |     if test_module::test_fn(n) {
+   |        ^^^^^^^^^^^ use of undeclared type or module `test_module`

--- a/codegen/ui_tests/rhai_fn_rename_collision_oneattr.rs
+++ b/codegen/ui_tests/rhai_fn_rename_collision_oneattr.rs
@@ -1,0 +1,32 @@
+use rhai::plugin::*;
+
+#[derive(Clone)]
+pub struct Point {
+    x: f32,
+    y: f32,
+}
+
+#[export_module]
+pub mod test_module {
+    pub use super::Point;
+    #[rhai_fn(name = "foo")]
+    pub fn test_fn(input: Point) -> bool {
+        input.x > input.y
+    }
+
+    pub fn foo(input: Point) -> bool {
+        input.x < input.y
+    }
+}
+
+fn main() {
+    let n = Point {
+        x: 0.0,
+        y: 10.0,
+    };
+    if test_module::test_fn(n) {
+        println!("yes");
+    } else {
+        println!("no");
+    }
+}

--- a/codegen/ui_tests/rhai_fn_rename_collision_oneattr.stderr
+++ b/codegen/ui_tests/rhai_fn_rename_collision_oneattr.stderr
@@ -1,0 +1,17 @@
+error: duplicate Rhai signature for 'foo'
+  --> $DIR/rhai_fn_rename_collision_oneattr.rs:12:15
+   |
+12 |     #[rhai_fn(name = "foo")]
+   |               ^^^^^^^^^^^^
+
+error: duplicated function 'foo'
+  --> $DIR/rhai_fn_rename_collision_oneattr.rs:17:12
+   |
+17 |     pub fn foo(input: Point) -> bool {
+   |            ^^^
+
+error[E0433]: failed to resolve: use of undeclared type or module `test_module`
+  --> $DIR/rhai_fn_rename_collision_oneattr.rs:27:8
+   |
+27 |     if test_module::test_fn(n) {
+   |        ^^^^^^^^^^^ use of undeclared type or module `test_module`

--- a/codegen/ui_tests/rhai_fn_rename_dot.rs
+++ b/codegen/ui_tests/rhai_fn_rename_dot.rs
@@ -1,0 +1,28 @@
+use rhai::plugin::*;
+
+#[derive(Clone)]
+pub struct Point {
+    x: f32,
+    y: f32,
+}
+
+#[export_module]
+pub mod test_module {
+    pub use super::Point;
+    #[rhai_fn(name = "foo.bar")]
+    pub fn test_fn(input: Point) -> bool {
+        input.x > input.y
+    }
+}
+
+fn main() {
+    let n = Point {
+        x: 0.0,
+        y: 10.0,
+    };
+    if test_module::test_fn(n) {
+        println!("yes");
+    } else {
+        println!("no");
+    }
+}

--- a/codegen/ui_tests/rhai_fn_rename_dot.stderr
+++ b/codegen/ui_tests/rhai_fn_rename_dot.stderr
@@ -1,0 +1,11 @@
+error: Rhai function names may not contain dot
+  --> $DIR/rhai_fn_rename_dot.rs:12:15
+   |
+12 |     #[rhai_fn(name = "foo.bar")]
+   |               ^^^^^^^^^^^^^^^^
+
+error[E0433]: failed to resolve: use of undeclared type or module `test_module`
+  --> $DIR/rhai_fn_rename_dot.rs:23:8
+   |
+23 |     if test_module::test_fn(n) {
+   |        ^^^^^^^^^^^ use of undeclared type or module `test_module`


### PR DESCRIPTION
This fixes some functional tests that I'm surprised still worked after the `export_fn` changes @schungx made, and also implements three new restrictions on `rhai_fn(name = "...")`:

1. A `rhai_fn` name cannot contain the character `.`. I presume this is true of Rhai in general, since `.` is used for attribute reading such as `x.y`, so I decided to use this property to implement the other two checks.
1. A `rhai_fn` name cannot conflict with another `rhai_fn` name in the same module. The code checks for uniqueness in the Rhai engine: the function name and all parameter types, but not the return type.
1. A `rhai_fn` name cannot conflict with an existing Rust function which is not renamed. In this case, the conflict checks _names only_. This is to avoid Rust compiler errors in the generated module code, which would make the macro `panic!` later.

The third one might be more restrictive than necessary, but I have not fully investigated all the effects of the new rename behavior.