### PR TITLE
Implement export_* attributes for macros

### DIFF
--- a/codegen/src/attrs.rs
+++ b/codegen/src/attrs.rs
@@ -1,5 +1,18 @@
 use syn::{parse::ParseStream, parse::Parser, spanned::Spanned};
 
+#[derive(Debug)]
+pub enum ExportScope {
+    PubOnly,
+    Prefix(String),
+    All,
+}
+
+impl Default for ExportScope {
+    fn default() -> ExportScope {
+        ExportScope::PubOnly
+    }
+}
+
 pub trait ExportedParams: Sized {
     fn parse_stream(args: ParseStream) -> syn::Result<Self>;
     fn no_attrs() -> Self;

--- a/codegen/src/lib.rs
+++ b/codegen/src/lib.rs
@@ -124,10 +124,18 @@ pub fn export_fn(
 
 #[proc_macro_attribute]
 pub fn export_module(
-    _args: proc_macro::TokenStream,
+    args: proc_macro::TokenStream,
     input: proc_macro::TokenStream,
 ) -> proc_macro::TokenStream {
-    let module_def = parse_macro_input!(input as module::Module);
+    let parsed_params = match crate::attrs::outer_item_attributes(args.into(), "export_module") {
+        Ok(args) => args,
+        Err(err) => return proc_macro::TokenStream::from(err.to_compile_error()),
+    };
+    let mut module_def = parse_macro_input!(input as module::Module);
+    if let Err(e) = module_def.set_params(parsed_params) {
+        return e.to_compile_error().into();
+    }
+
     let tokens = module_def.generate();
     proc_macro::TokenStream::from(tokens)
 }


### PR DESCRIPTION
This adds attributes to support controlling exports from Rust to Rhai. There are three attributes placed on `#[export_module]` to select:
* `export_pub` is the current behavior: items marked `pub` are exported, those that are not are skipped. If you don't specify any of these new attributes, this remains the default.
* `export_prefix = "string"` checks the exported name (the function name, or the `name = ...` attribute if present) and only export the time if the name starts with the provided string.
* `export_all` exports everything. The only way to not export something is to put a `skip` attribute on it.

On my own machine, there are some failing tests -- but those tests fail on the base commit, which passed CI. Let's see what CI does...