### PR TITLE
Fix for export_prefix attribute on module macros

### DIFF
--- a/codegen/src/function.rs
+++ b/codegen/src/function.rs
@@ -228,7 +228,7 @@ impl ExportedFn {
         let keep = match (self.params.skip, parent_scope) {
             (true, _) => false,
             (_, ExportScope::PubOnly) => self.is_public,
-            (_, ExportScope::Prefix(s)) => self.exported_name().as_ref().starts_with(s),
+            (_, ExportScope::Prefix(s)) => self.name().to_string().starts_with(s),
             (_, ExportScope::All) => true,
         };
         self.params.skip = !keep;

--- a/codegen/tests/test_modules.rs
+++ b/codegen/tests/test_modules.rs
@@ -229,16 +229,16 @@ mod export_by_prefix {
         use rhai::{FLOAT, INT};
 
         #[rhai_fn(name = "foo_add_f")]
-        pub fn add_float(f1: FLOAT, f2: FLOAT) -> FLOAT {
+        pub fn foo_add1(f1: FLOAT, f2: FLOAT) -> FLOAT {
             f1 + f2
         }
 
-        #[rhai_fn(name = "foo_add_i")]
-        fn add_int(i1: INT, i2: INT) -> INT {
+        #[rhai_fn(name = "bar_add_i")]
+        fn foo_add_int(i1: INT, i2: INT) -> INT {
             i1 + i2
         }
 
-        #[rhai_fn(name = "bar_add")]
+        #[rhai_fn(name = "foo_add_float2")]
         pub fn add_float2(f1: FLOAT, f2: FLOAT) -> FLOAT {
             f1 + f2
         }
@@ -271,7 +271,7 @@ fn export_by_prefix_test() -> Result<(), Box<EvalAltResult>> {
        let fx = math::foo_add_f(ex, 1.0);
        let gx = math::foo_m(41.0, 1.0);
        let ei = 41;
-       let fi = math::foo_add_i(ei, 1);
+       let fi = math::bar_add_i(ei, 1);
        let gi = math::foo_n(41, 1);
        [fx, gx, fi, gi]
        "#,
@@ -284,21 +284,11 @@ fn export_by_prefix_test() -> Result<(), Box<EvalAltResult>> {
     assert!(matches!(*engine.eval::<FLOAT>(
         r#"import "Math::Advanced" as math;
        let ex = 41.0;
-       let fx = math::bar_add(ex, 1.0);
+       let fx = math::foo_add_float2(ex, 1.0);
        fx
        "#).unwrap_err(),
        EvalAltResult::ErrorFunctionNotFound(s, p)
-            if s == "math::bar_add (f64, f64)"
-            && p == rhai::Position::new(3, 23)));
-
-    assert!(matches!(*engine.eval::<FLOAT>(
-        r#"import "Math::Advanced" as math;
-       let ex = 41.0;
-       let fx = math::add_float2(ex, 1.0);
-       fx
-       "#).unwrap_err(),
-       EvalAltResult::ErrorFunctionNotFound(s, p)
-            if s == "math::add_float2 (f64, f64)"
+            if s == "math::foo_add_float2 (f64, f64)"
             && p == rhai::Position::new(3, 23)));
 
     assert!(matches!(*engine.eval::<FLOAT>(


### PR DESCRIPTION
This causes `export_prefix` to filter based on _Rust_ item name, intentionally _not_ taking any export names set by the `name = ...` attribute into account. @schungx pointed this out in #38.

One thing I did not do was presume that the presence of an export name automatically assumes that it should be exported. To handle that case, I am planning an `always` attribute that is the inverse of `skip`.

---

This is being merged to `master`, because I merged the other fix there by mistake. Once this is merged, I'd like `master` to be merged into `plugins` for the last little bit of work I do on this feature.
