### PR TITLE
Add workspace, for both publishing and codegen tests

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -52,7 +52,7 @@ jobs:
       uses: actions-rs/cargo@v1
       with:
         command: test
-        args: --all ${{matrix.flags}}
+        args: ${{matrix.flags}}
   # no-std builds are a bit more extensive to test
   no_std_build:
     name: NoStdBuild

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,3 +1,9 @@
+[workspace]
+members = [
+  ".",
+  "codegen"
+]
+
 [package]
 name = "rhai"
 version = "0.18.3"

--- a/codegen/ui_tests/rhai_fn_non_clonable_return.rs
+++ b/codegen/ui_tests/rhai_fn_non_clonable_return.rs
@@ -1,0 +1,27 @@
+use rhai::plugin::*;
+
+struct NonClonable {
+    a: f32,
+    b: u32,
+    c: char,
+    d: bool,
+}
+
+#[export_fn]
+pub fn test_fn(input: f32) -> NonClonable {
+    NonClonable {
+        a: input,
+        b: 10,
+        c: 'a',
+        d: true,
+    }
+}
+
+fn main() {
+    let n = test_fn(20.0);
+    if n.c == 'a' {
+        println!("yes");
+    } else {
+        println!("no");
+    }
+}

--- a/codegen/ui_tests/rhai_fn_non_clonable_return.stderr
+++ b/codegen/ui_tests/rhai_fn_non_clonable_return.stderr
@@ -1,0 +1,10 @@
+error[E0277]: the trait bound `NonClonable: Clone` is not satisfied
+   --> $DIR/rhai_fn_non_clonable_return.rs:11:8
+    |
+11  | pub fn test_fn(input: f32) -> NonClonable {
+    |        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ the trait `Clone` is not implemented for `NonClonable`
+    |
+   ::: $WORKSPACE/src/any.rs
+    |
+    |     pub fn from<T: Variant + Clone>(value: T) -> Self {
+    |                              ----- required by this bound in `rhai::Dynamic::from`

--- a/codegen/ui_tests/rhai_mod_non_clonable_return.rs
+++ b/codegen/ui_tests/rhai_mod_non_clonable_return.rs
@@ -1,0 +1,29 @@
+use rhai::plugin::*;
+
+struct NonClonable {
+    a: f32,
+    b: u32,
+    c: char,
+    d: bool,
+}
+
+#[export_module]
+pub mod test_mod {
+    pub fn test_fn(input: f32) -> NonClonable {
+        NonClonable {
+            a: input,
+            b: 10,
+            c: 'a',
+            d: true,
+        }
+    }
+}
+
+fn main() {
+    let n = test_mod::test_fn(20.0);
+    if n.c == 'a' {
+        println!("yes");
+    } else {
+        println!("no");
+    }
+}

--- a/codegen/ui_tests/rhai_mod_non_clonable_return.stderr
+++ b/codegen/ui_tests/rhai_mod_non_clonable_return.stderr
@@ -1,0 +1,10 @@
+error[E0277]: the trait bound `NonClonable: Clone` is not satisfied
+   --> $DIR/rhai_mod_non_clonable_return.rs:12:12
+    |
+12  |     pub fn test_fn(input: f32) -> NonClonable {
+    |            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ the trait `Clone` is not implemented for `NonClonable`
+    |
+   ::: $WORKSPACE/src/any.rs
+    |
+    |     pub fn from<T: Variant + Clone>(value: T) -> Self {
+    |                              ----- required by this bound in `rhai::Dynamic::from`

--- a/no_std/no_std_test/Cargo.toml
+++ b/no_std/no_std_test/Cargo.toml
@@ -1,5 +1,7 @@
 cargo-features = ["named-profiles"]
 
+[workspace]
+
 [package]
 name = "no_std_test"
 version = "0.1.0"


### PR DESCRIPTION
This PR puts Rhai into a workspace, with `codegen` as a child module. This solves two problems:

1. There were future questions in my mind about how Rhai would be released, now that it depends on a separate "internal" crate. A workspace is the easiest answer to that question.

2. There were some UI tests that I couldn't add due to issues with `trybuild`. The crate's author pointed out that my issues would be solved by putting `codegen` into a workspace with its parent crate.

Based on other projects, I was expecting to have to rearrange the code for Rhai completely to achieve this. But then last weekend, the workspace definition included here was pointed out as legal, and a trivial way to achieve this goal.