### PR TITLE
Reorganize get/set/index code into FnSpecialAccess

### DIFF
--- a/codegen/src/attrs.rs
+++ b/codegen/src/attrs.rs
@@ -22,6 +22,7 @@ pub trait ExportedParams: Sized {
 pub struct AttrItem {
     pub key: proc_macro2::Ident,
     pub value: Option<syn::LitStr>,
+    pub span: proc_macro2::Span,
 }
 
 pub struct ExportInfo {
@@ -46,6 +47,7 @@ pub fn parse_punctuated_items(
 
     let mut attrs: Vec<AttrItem> = Vec::new();
     for arg in arg_list {
+        let arg_span = arg.span();
         let (key, value) = match arg {
             syn::Expr::Assign(syn::ExprAssign {
                 ref left,
@@ -78,7 +80,7 @@ pub fn parse_punctuated_items(
                 .ok_or_else(|| syn::Error::new(attr_path.span(), "expecting attribute name"))?,
             x => return Err(syn::Error::new(x.span(), "expecting identifier")),
         };
-        attrs.push(AttrItem { key, value });
+        attrs.push(AttrItem { key, value, span: arg_span });
     }
 
     Ok(ExportInfo { item_span: list_span, items: attrs })

--- a/codegen/src/function.rs
+++ b/codegen/src/function.rs
@@ -87,6 +87,10 @@ impl ExportedParams for ExportedFnParams {
                                format!("use attribute 'setter = \"{}\"' instead",
                                        &s.value()["set$".len()..])))
                 },
+                ("name", Some(s)) if s.value().contains('$') => {
+                    return Err(syn::Error::new(s.span(),
+                               "Rhai function names may not contain dollar sign"))
+                },
                 ("name", Some(s)) if s.value().contains('.') => {
                     return Err(syn::Error::new(s.span(),
                                "Rhai function names may not contain dot"))

--- a/codegen/src/module.rs
+++ b/codegen/src/module.rs
@@ -53,7 +53,7 @@ impl ExportedParams for ExportedModParams {
         let mut skip = false;
         let mut scope = ExportScope::default();
         for attr in attrs {
-            let AttrItem { key, value } = attr;
+            let AttrItem { key, value, .. } = attr;
             match (key.to_string().as_ref(), value) {
                 ("name", Some(s)) => name = Some(s.value()),
                 ("name", None) => return Err(syn::Error::new(key.span(), "requires value")),

--- a/codegen/src/rhai_module.rs
+++ b/codegen/src/rhai_module.rs
@@ -67,11 +67,7 @@ pub(crate) fn generate_body(
             &format!("{}_token", function.name().to_string()),
             function.name().span(),
         );
-        let reg_names = function
-            .params()
-            .name
-            .clone()
-            .unwrap_or_else(|| vec![function.name().to_string()]);
+        let reg_names = function.exported_names();
 
         let fn_input_types: Vec<syn::Expr> = function
             .arg_list()
@@ -110,9 +106,7 @@ pub(crate) fn generate_body(
             })
             .collect();
 
-        for reg_name in reg_names {
-            let fn_literal = syn::LitStr::new(&reg_name, proc_macro2::Span::call_site());
-
+        for fn_literal in reg_names {
             set_fn_stmts.push(
                 syn::parse2::<syn::Stmt>(quote! {
                     m.set_fn(#fn_literal, FnAccess::Public, &[#(#fn_input_types),*],

--- a/codegen/src/test/module.rs
+++ b/codegen/src/test/module.rs
@@ -1132,6 +1132,67 @@ mod generate_tests {
     }
 
     #[test]
+    fn one_getter_and_rename_fn_module() {
+        let input_tokens: TokenStream = quote! {
+            pub mod one_fn {
+                #[rhai_fn(name = "square", get = "square")]
+                pub fn int_foo(x: &mut u64) -> u64 {
+                    (*x) * (*x)
+                }
+            }
+        };
+
+        let expected_tokens = quote! {
+            pub mod one_fn {
+                pub fn int_foo(x: &mut u64) -> u64 {
+                    (*x) * (*x)
+                }
+                #[allow(unused_imports)]
+                use super::*;
+                #[allow(unused_mut)]
+                pub fn rhai_module_generate() -> Module {
+                    let mut m = Module::new();
+                    m.set_fn("square", FnAccess::Public, &[core::any::TypeId::of::<u64>()],
+                             CallableFunction::from_plugin(int_foo_token()));
+                    m.set_fn("get$square", FnAccess::Public, &[core::any::TypeId::of::<u64>()],
+                             CallableFunction::from_plugin(int_foo_token()));
+                    m
+                }
+                #[allow(non_camel_case_types)]
+                struct int_foo_token();
+                impl PluginFunction for int_foo_token {
+                    fn call(&self,
+                            args: &mut [&mut Dynamic], pos: Position
+                    ) -> Result<Dynamic, Box<EvalAltResult>> {
+                        debug_assert_eq!(args.len(), 1usize,
+                                            "wrong arg count: {} != {}", args.len(), 1usize);
+                        let arg0: &mut _ = &mut args[0usize].write_lock::<u64>().unwrap();
+                        Ok(Dynamic::from(int_foo(arg0)))
+                    }
+
+                    fn is_method_call(&self) -> bool { true }
+                    fn is_varadic(&self) -> bool { false }
+                    fn clone_boxed(&self) -> Box<dyn PluginFunction> {
+                        Box::new(int_foo_token())
+                    }
+                    fn input_types(&self) -> Box<[TypeId]> {
+                        new_vec![TypeId::of::<u64>()].into_boxed_slice()
+                    }
+                }
+                pub fn int_foo_token_callable() -> CallableFunction {
+                    CallableFunction::from_plugin(int_foo_token())
+                }
+                pub fn int_foo_token_input_types() -> Box<[TypeId]> {
+                    int_foo_token().input_types()
+                }
+            }
+        };
+
+        let item_mod = syn::parse2::<Module>(input_tokens).unwrap();
+        assert_streams_eq(item_mod.generate(), expected_tokens);
+    }
+
+    #[test]
     fn one_setter_fn_module() {
         let input_tokens: TokenStream = quote! {
             pub mod one_fn {
@@ -1152,6 +1213,67 @@ mod generate_tests {
                 #[allow(unused_mut)]
                 pub fn rhai_module_generate() -> Module {
                     let mut m = Module::new();
+                    m.set_fn("set$squared", FnAccess::Public, &[core::any::TypeId::of::<u64>()],
+                             CallableFunction::from_plugin(int_foo_token()));
+                    m
+                }
+                #[allow(non_camel_case_types)]
+                struct int_foo_token();
+                impl PluginFunction for int_foo_token {
+                    fn call(&self,
+                            args: &mut [&mut Dynamic], pos: Position
+                    ) -> Result<Dynamic, Box<EvalAltResult>> {
+                        debug_assert_eq!(args.len(), 1usize,
+                                            "wrong arg count: {} != {}", args.len(), 1usize);
+                        let arg0: &mut _ = &mut args[0usize].write_lock::<u64>().unwrap();
+                        Ok(Dynamic::from(int_foo(arg0)))
+                    }
+
+                    fn is_method_call(&self) -> bool { true }
+                    fn is_varadic(&self) -> bool { false }
+                    fn clone_boxed(&self) -> Box<dyn PluginFunction> {
+                        Box::new(int_foo_token())
+                    }
+                    fn input_types(&self) -> Box<[TypeId]> {
+                        new_vec![TypeId::of::<u64>()].into_boxed_slice()
+                    }
+                }
+                pub fn int_foo_token_callable() -> CallableFunction {
+                    CallableFunction::from_plugin(int_foo_token())
+                }
+                pub fn int_foo_token_input_types() -> Box<[TypeId]> {
+                    int_foo_token().input_types()
+                }
+            }
+        };
+
+        let item_mod = syn::parse2::<Module>(input_tokens).unwrap();
+        assert_streams_eq(item_mod.generate(), expected_tokens);
+    }
+
+    #[test]
+    fn one_setter_and_rename_fn_module() {
+        let input_tokens: TokenStream = quote! {
+            pub mod one_fn {
+                #[rhai_fn(name = "set_sq", set = "squared")]
+                pub fn int_foo(x: &mut u64) {
+                    *x = (*x) * (*x)
+                }
+            }
+        };
+
+        let expected_tokens = quote! {
+            pub mod one_fn {
+                pub fn int_foo(x: &mut u64) {
+                    *x = (*x) * (*x)
+                }
+                #[allow(unused_imports)]
+                use super::*;
+                #[allow(unused_mut)]
+                pub fn rhai_module_generate() -> Module {
+                    let mut m = Module::new();
+                    m.set_fn("set_sq", FnAccess::Public, &[core::any::TypeId::of::<u64>()],
+                             CallableFunction::from_plugin(int_foo_token()));
                     m.set_fn("set$squared", FnAccess::Public, &[core::any::TypeId::of::<u64>()],
                              CallableFunction::from_plugin(int_foo_token()));
                     m
@@ -1254,6 +1376,73 @@ mod generate_tests {
     }
 
     #[test]
+    fn one_index_getter_and_rename_fn_module() {
+        let input_tokens: TokenStream = quote! {
+            pub mod one_index_fn {
+                #[rhai_fn(name = "get", index_get)]
+                pub fn get_by_index(x: &mut MyCollection, i: u64) -> FLOAT {
+                    x.get(i)
+                }
+            }
+        };
+
+        let expected_tokens = quote! {
+            pub mod one_index_fn {
+                pub fn get_by_index(x: &mut MyCollection, i: u64) -> FLOAT {
+                    x.get(i)
+                }
+                #[allow(unused_imports)]
+                use super::*;
+                #[allow(unused_mut)]
+                pub fn rhai_module_generate() -> Module {
+                    let mut m = Module::new();
+                    m.set_fn("get", FnAccess::Public,
+                             &[core::any::TypeId::of::<MyCollection>(),
+                               core::any::TypeId::of::<u64>()],
+                             CallableFunction::from_plugin(get_by_index_token()));
+                    m.set_fn("index$get$", FnAccess::Public,
+                             &[core::any::TypeId::of::<MyCollection>(),
+                               core::any::TypeId::of::<u64>()],
+                             CallableFunction::from_plugin(get_by_index_token()));
+                    m
+                }
+                #[allow(non_camel_case_types)]
+                struct get_by_index_token();
+                impl PluginFunction for get_by_index_token {
+                    fn call(&self,
+                            args: &mut [&mut Dynamic], pos: Position
+                    ) -> Result<Dynamic, Box<EvalAltResult>> {
+                        debug_assert_eq!(args.len(), 2usize,
+                                            "wrong arg count: {} != {}", args.len(), 2usize);
+                        let arg1 = mem::take(args[1usize]).clone().cast::<u64>();
+                        let arg0: &mut _ = &mut args[0usize].write_lock::<MyCollection>().unwrap();
+                        Ok(Dynamic::from(get_by_index(arg0, arg1)))
+                    }
+
+                    fn is_method_call(&self) -> bool { true }
+                    fn is_varadic(&self) -> bool { false }
+                    fn clone_boxed(&self) -> Box<dyn PluginFunction> {
+                        Box::new(get_by_index_token())
+                    }
+                    fn input_types(&self) -> Box<[TypeId]> {
+                        new_vec![TypeId::of::<MyCollection>(),
+                                 TypeId::of::<u64>()].into_boxed_slice()
+                    }
+                }
+                pub fn get_by_index_token_callable() -> CallableFunction {
+                    CallableFunction::from_plugin(get_by_index_token())
+                }
+                pub fn get_by_index_token_input_types() -> Box<[TypeId]> {
+                    get_by_index_token().input_types()
+                }
+            }
+        };
+
+        let item_mod = syn::parse2::<Module>(input_tokens).unwrap();
+        assert_streams_eq(item_mod.generate(), expected_tokens);
+    }
+
+    #[test]
     fn one_index_setter_fn_module() {
         let input_tokens: TokenStream = quote! {
             pub mod one_index_fn {
@@ -1274,6 +1463,77 @@ mod generate_tests {
                 #[allow(unused_mut)]
                 pub fn rhai_module_generate() -> Module {
                     let mut m = Module::new();
+                    m.set_fn("index$set$", FnAccess::Public,
+                             &[core::any::TypeId::of::<MyCollection>(),
+                               core::any::TypeId::of::<u64>(),
+                               core::any::TypeId::of::<FLOAT>()],
+                             CallableFunction::from_plugin(set_by_index_token()));
+                    m
+                }
+                #[allow(non_camel_case_types)]
+                struct set_by_index_token();
+                impl PluginFunction for set_by_index_token {
+                    fn call(&self,
+                            args: &mut [&mut Dynamic], pos: Position
+                    ) -> Result<Dynamic, Box<EvalAltResult>> {
+                        debug_assert_eq!(args.len(), 3usize,
+                                            "wrong arg count: {} != {}", args.len(), 3usize);
+                        let arg1 = mem::take(args[1usize]).clone().cast::<u64>();
+                        let arg2 = mem::take(args[2usize]).clone().cast::<FLOAT>();
+                        let arg0: &mut _ = &mut args[0usize].write_lock::<MyCollection>().unwrap();
+                        Ok(Dynamic::from(set_by_index(arg0, arg1, arg2)))
+                    }
+
+                    fn is_method_call(&self) -> bool { true }
+                    fn is_varadic(&self) -> bool { false }
+                    fn clone_boxed(&self) -> Box<dyn PluginFunction> {
+                        Box::new(set_by_index_token())
+                    }
+                    fn input_types(&self) -> Box<[TypeId]> {
+                        new_vec![TypeId::of::<MyCollection>(),
+                                 TypeId::of::<u64>(),
+                                 TypeId::of::<FLOAT>()].into_boxed_slice()
+                    }
+                }
+                pub fn set_by_index_token_callable() -> CallableFunction {
+                    CallableFunction::from_plugin(set_by_index_token())
+                }
+                pub fn set_by_index_token_input_types() -> Box<[TypeId]> {
+                    set_by_index_token().input_types()
+                }
+            }
+        };
+
+        let item_mod = syn::parse2::<Module>(input_tokens).unwrap();
+        assert_streams_eq(item_mod.generate(), expected_tokens);
+    }
+
+    #[test]
+    fn one_index_setter_and_rename_fn_module() {
+        let input_tokens: TokenStream = quote! {
+            pub mod one_index_fn {
+                #[rhai_fn(name = "set", index_set)]
+                pub fn set_by_index(x: &mut MyCollection, i: u64, item: FLOAT) {
+                    x.entry(i).set(item)
+                }
+            }
+        };
+
+        let expected_tokens = quote! {
+            pub mod one_index_fn {
+                pub fn set_by_index(x: &mut MyCollection, i: u64, item: FLOAT) {
+                    x.entry(i).set(item)
+                }
+                #[allow(unused_imports)]
+                use super::*;
+                #[allow(unused_mut)]
+                pub fn rhai_module_generate() -> Module {
+                    let mut m = Module::new();
+                    m.set_fn("set", FnAccess::Public,
+                             &[core::any::TypeId::of::<MyCollection>(),
+                               core::any::TypeId::of::<u64>(),
+                               core::any::TypeId::of::<FLOAT>()],
+                             CallableFunction::from_plugin(set_by_index_token()));
                     m.set_fn("index$set$", FnAccess::Public,
                              &[core::any::TypeId::of::<MyCollection>(),
                                core::any::TypeId::of::<u64>(),

--- a/codegen/src/test/module.rs
+++ b/codegen/src/test/module.rs
@@ -1197,23 +1197,25 @@ mod generate_tests {
         let input_tokens: TokenStream = quote! {
             pub mod one_fn {
                 #[rhai_fn(set = "squared")]
-                pub fn int_foo(x: &mut u64) {
-                    *x = (*x) * (*x)
+                pub fn int_foo(x: &mut u64, y: u64) {
+                    *x = y * y
                 }
             }
         };
 
         let expected_tokens = quote! {
             pub mod one_fn {
-                pub fn int_foo(x: &mut u64) {
-                    *x = (*x) * (*x)
+                pub fn int_foo(x: &mut u64, y: u64) {
+                    *x = y * y
                 }
                 #[allow(unused_imports)]
                 use super::*;
                 #[allow(unused_mut)]
                 pub fn rhai_module_generate() -> Module {
                     let mut m = Module::new();
-                    m.set_fn("set$squared", FnAccess::Public, &[core::any::TypeId::of::<u64>()],
+                    m.set_fn("set$squared", FnAccess::Public,
+                             &[core::any::TypeId::of::<u64>(),
+                               core::any::TypeId::of::<u64>()],
                              CallableFunction::from_plugin(int_foo_token()));
                     m
                 }
@@ -1223,10 +1225,11 @@ mod generate_tests {
                     fn call(&self,
                             args: &mut [&mut Dynamic], pos: Position
                     ) -> Result<Dynamic, Box<EvalAltResult>> {
-                        debug_assert_eq!(args.len(), 1usize,
-                                            "wrong arg count: {} != {}", args.len(), 1usize);
+                        debug_assert_eq!(args.len(), 2usize,
+                                            "wrong arg count: {} != {}", args.len(), 2usize);
+                        let arg1 = mem::take(args[1usize]).clone().cast::<u64>();
                         let arg0: &mut _ = &mut args[0usize].write_lock::<u64>().unwrap();
-                        Ok(Dynamic::from(int_foo(arg0)))
+                        Ok(Dynamic::from(int_foo(arg0, arg1)))
                     }
 
                     fn is_method_call(&self) -> bool { true }
@@ -1235,7 +1238,7 @@ mod generate_tests {
                         Box::new(int_foo_token())
                     }
                     fn input_types(&self) -> Box<[TypeId]> {
-                        new_vec![TypeId::of::<u64>()].into_boxed_slice()
+                        new_vec![TypeId::of::<u64>(), TypeId::of::<u64>()].into_boxed_slice()
                     }
                 }
                 pub fn int_foo_token_callable() -> CallableFunction {
@@ -1256,25 +1259,29 @@ mod generate_tests {
         let input_tokens: TokenStream = quote! {
             pub mod one_fn {
                 #[rhai_fn(name = "set_sq", set = "squared")]
-                pub fn int_foo(x: &mut u64) {
-                    *x = (*x) * (*x)
+                pub fn int_foo(x: &mut u64, y: u64) {
+                    *x = y * y
                 }
             }
         };
 
         let expected_tokens = quote! {
             pub mod one_fn {
-                pub fn int_foo(x: &mut u64) {
-                    *x = (*x) * (*x)
+                pub fn int_foo(x: &mut u64, y: u64) {
+                    *x = y * y
                 }
                 #[allow(unused_imports)]
                 use super::*;
                 #[allow(unused_mut)]
                 pub fn rhai_module_generate() -> Module {
                     let mut m = Module::new();
-                    m.set_fn("set_sq", FnAccess::Public, &[core::any::TypeId::of::<u64>()],
+                    m.set_fn("set_sq", FnAccess::Public,
+                             &[core::any::TypeId::of::<u64>(),
+                               core::any::TypeId::of::<u64>()],
                              CallableFunction::from_plugin(int_foo_token()));
-                    m.set_fn("set$squared", FnAccess::Public, &[core::any::TypeId::of::<u64>()],
+                    m.set_fn("set$squared", FnAccess::Public,
+                             &[core::any::TypeId::of::<u64>(),
+                               core::any::TypeId::of::<u64>()],
                              CallableFunction::from_plugin(int_foo_token()));
                     m
                 }
@@ -1284,10 +1291,11 @@ mod generate_tests {
                     fn call(&self,
                             args: &mut [&mut Dynamic], pos: Position
                     ) -> Result<Dynamic, Box<EvalAltResult>> {
-                        debug_assert_eq!(args.len(), 1usize,
-                                            "wrong arg count: {} != {}", args.len(), 1usize);
+                        debug_assert_eq!(args.len(), 2usize,
+                                            "wrong arg count: {} != {}", args.len(), 2usize);
+                        let arg1 = mem::take(args[1usize]).clone().cast::<u64>();
                         let arg0: &mut _ = &mut args[0usize].write_lock::<u64>().unwrap();
-                        Ok(Dynamic::from(int_foo(arg0)))
+                        Ok(Dynamic::from(int_foo(arg0, arg1)))
                     }
 
                     fn is_method_call(&self) -> bool { true }
@@ -1296,7 +1304,7 @@ mod generate_tests {
                         Box::new(int_foo_token())
                     }
                     fn input_types(&self) -> Box<[TypeId]> {
-                        new_vec![TypeId::of::<u64>()].into_boxed_slice()
+                        new_vec![TypeId::of::<u64>(), TypeId::of::<u64>()].into_boxed_slice()
                     }
                 }
                 pub fn int_foo_token_callable() -> CallableFunction {

--- a/codegen/ui_tests/rhai_fn_getter_conflict.rs
+++ b/codegen/ui_tests/rhai_fn_getter_conflict.rs
@@ -1,0 +1,28 @@
+use rhai::plugin::*;
+
+#[derive(Clone)]
+pub struct Point {
+    x: f32,
+    y: f32,
+}
+
+#[export_module]
+pub mod test_module {
+    pub use super::Point;
+    #[rhai_fn(name = "foo", get = "foo", set = "bar")]
+    pub fn test_fn(input: Point) -> bool {
+        input.x > input.y
+    }
+}
+
+fn main() {
+    let n = Point {
+        x: 0.0,
+        y: 10.0,
+    };
+    if test_module::test_fn(n) {
+        println!("yes");
+    } else {
+        println!("no");
+    }
+}

--- a/codegen/ui_tests/rhai_fn_getter_conflict.stderr
+++ b/codegen/ui_tests/rhai_fn_getter_conflict.stderr
@@ -4,8 +4,8 @@ error: conflicting setter
 12 |     #[rhai_fn(name = "foo", get = "foo", set = "bar")]
    |                                          ^^^^^^^^^^^
 
-error[E0433]: failed to resolve: use of undeclared type or module `test_module`
+error[E0433]: failed to resolve: use of undeclared crate or module `test_module`
   --> $DIR/rhai_fn_getter_conflict.rs:23:8
    |
 23 |     if test_module::test_fn(n) {
-   |        ^^^^^^^^^^^ use of undeclared type or module `test_module`
+   |        ^^^^^^^^^^^ use of undeclared crate or module `test_module`

--- a/codegen/ui_tests/rhai_fn_getter_conflict.stderr
+++ b/codegen/ui_tests/rhai_fn_getter_conflict.stderr
@@ -1,0 +1,11 @@
+error: conflicting setter
+  --> $DIR/rhai_fn_getter_conflict.rs:12:42
+   |
+12 |     #[rhai_fn(name = "foo", get = "foo", set = "bar")]
+   |                                          ^^^^^^^^^^^
+
+error[E0433]: failed to resolve: use of undeclared type or module `test_module`
+  --> $DIR/rhai_fn_getter_conflict.rs:23:8
+   |
+23 |     if test_module::test_fn(n) {
+   |        ^^^^^^^^^^^ use of undeclared type or module `test_module`

--- a/codegen/ui_tests/rhai_fn_getter_multiple.rs
+++ b/codegen/ui_tests/rhai_fn_getter_multiple.rs
@@ -1,0 +1,28 @@
+use rhai::plugin::*;
+
+#[derive(Clone)]
+pub struct Point {
+    x: f32,
+    y: f32,
+}
+
+#[export_module]
+pub mod test_module {
+    pub use super::Point;
+    #[rhai_fn(name = "foo", get = "foo", get = "bar")]
+    pub fn test_fn(input: Point) -> bool {
+        input.x > input.y
+    }
+}
+
+fn main() {
+    let n = Point {
+        x: 0.0,
+        y: 10.0,
+    };
+    if test_module::test_fn(n) {
+        println!("yes");
+    } else {
+        println!("no");
+    }
+}

--- a/codegen/ui_tests/rhai_fn_getter_multiple.stderr
+++ b/codegen/ui_tests/rhai_fn_getter_multiple.stderr
@@ -4,8 +4,8 @@ error: conflicting getter
 12 |     #[rhai_fn(name = "foo", get = "foo", get = "bar")]
    |                                          ^^^^^^^^^^^
 
-error[E0433]: failed to resolve: use of undeclared type or module `test_module`
+error[E0433]: failed to resolve: use of undeclared crate or module `test_module`
   --> $DIR/rhai_fn_getter_multiple.rs:23:8
    |
 23 |     if test_module::test_fn(n) {
-   |        ^^^^^^^^^^^ use of undeclared type or module `test_module`
+   |        ^^^^^^^^^^^ use of undeclared crate or module `test_module`

--- a/codegen/ui_tests/rhai_fn_getter_multiple.stderr
+++ b/codegen/ui_tests/rhai_fn_getter_multiple.stderr
@@ -1,0 +1,11 @@
+error: conflicting getter
+  --> $DIR/rhai_fn_getter_multiple.rs:12:42
+   |
+12 |     #[rhai_fn(name = "foo", get = "foo", get = "bar")]
+   |                                          ^^^^^^^^^^^
+
+error[E0433]: failed to resolve: use of undeclared type or module `test_module`
+  --> $DIR/rhai_fn_getter_multiple.rs:23:8
+   |
+23 |     if test_module::test_fn(n) {
+   |        ^^^^^^^^^^^ use of undeclared type or module `test_module`

--- a/codegen/ui_tests/rhai_fn_getter_return.rs
+++ b/codegen/ui_tests/rhai_fn_getter_return.rs
@@ -1,0 +1,29 @@
+use rhai::plugin::*;
+
+#[derive(Clone)]
+pub struct Point {
+    x: f32,
+    y: f32,
+}
+
+#[export_module]
+pub mod test_module {
+    pub use super::Point;
+    #[rhai_fn(get = "foo")]
+    pub fn test_fn(input: &mut Point) {
+        input.x *= 2.0;
+    }
+}
+
+fn main() {
+    let mut n = Point {
+        x: 0.0,
+        y: 10.0,
+    };
+    test_module::test_fn(&mut n);
+    if n.x > 10.0 {
+        println!("yes");
+    } else {
+        println!("no");
+    }
+}

--- a/codegen/ui_tests/rhai_fn_getter_return.stderr
+++ b/codegen/ui_tests/rhai_fn_getter_return.stderr
@@ -4,8 +4,8 @@ error: property getter must return a value
 13 |     pub fn test_fn(input: &mut Point) {
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-error[E0433]: failed to resolve: use of undeclared type or module `test_module`
+error[E0433]: failed to resolve: use of undeclared crate or module `test_module`
   --> $DIR/rhai_fn_getter_return.rs:23:5
    |
 23 |     test_module::test_fn(&mut n);
-   |     ^^^^^^^^^^^ use of undeclared type or module `test_module`
+   |     ^^^^^^^^^^^ use of undeclared crate or module `test_module`

--- a/codegen/ui_tests/rhai_fn_getter_return.stderr
+++ b/codegen/ui_tests/rhai_fn_getter_return.stderr
@@ -1,0 +1,11 @@
+error: property getter must return a value
+  --> $DIR/rhai_fn_getter_return.rs:13:9
+   |
+13 |     pub fn test_fn(input: &mut Point) {
+   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+error[E0433]: failed to resolve: use of undeclared type or module `test_module`
+  --> $DIR/rhai_fn_getter_return.rs:23:5
+   |
+23 |     test_module::test_fn(&mut n);
+   |     ^^^^^^^^^^^ use of undeclared type or module `test_module`

--- a/codegen/ui_tests/rhai_fn_getter_signature.rs
+++ b/codegen/ui_tests/rhai_fn_getter_signature.rs
@@ -1,0 +1,28 @@
+use rhai::plugin::*;
+
+#[derive(Clone)]
+pub struct Point {
+    x: f32,
+    y: f32,
+}
+
+#[export_module]
+pub mod test_module {
+    pub use super::Point;
+    #[rhai_fn(get = "foo")]
+    pub fn test_fn(input: Point, value: bool) -> bool {
+        value && input.x > input.y
+    }
+}
+
+fn main() {
+    let n = Point {
+        x: 0.0,
+        y: 10.0,
+    };
+    if test_module::test_fn(n, true) {
+        println!("yes");
+    } else {
+        println!("no");
+    }
+}

--- a/codegen/ui_tests/rhai_fn_getter_signature.stderr
+++ b/codegen/ui_tests/rhai_fn_getter_signature.stderr
@@ -4,8 +4,8 @@ error: property getter requires exactly 1 argument
 13 |     pub fn test_fn(input: Point, value: bool) -> bool {
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-error[E0433]: failed to resolve: use of undeclared type or module `test_module`
+error[E0433]: failed to resolve: use of undeclared crate or module `test_module`
   --> $DIR/rhai_fn_getter_signature.rs:23:8
    |
 23 |     if test_module::test_fn(n, true) {
-   |        ^^^^^^^^^^^ use of undeclared type or module `test_module`
+   |        ^^^^^^^^^^^ use of undeclared crate or module `test_module`

--- a/codegen/ui_tests/rhai_fn_getter_signature.stderr
+++ b/codegen/ui_tests/rhai_fn_getter_signature.stderr
@@ -1,0 +1,11 @@
+error: property getter requires exactly 1 argument
+  --> $DIR/rhai_fn_getter_signature.rs:13:9
+   |
+13 |     pub fn test_fn(input: Point, value: bool) -> bool {
+   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+error[E0433]: failed to resolve: use of undeclared type or module `test_module`
+  --> $DIR/rhai_fn_getter_signature.rs:23:8
+   |
+23 |     if test_module::test_fn(n, true) {
+   |        ^^^^^^^^^^^ use of undeclared type or module `test_module`

--- a/codegen/ui_tests/rhai_fn_index_getter_multiple.rs
+++ b/codegen/ui_tests/rhai_fn_index_getter_multiple.rs
@@ -1,0 +1,28 @@
+use rhai::plugin::*;
+
+#[derive(Clone)]
+pub struct Point {
+    x: f32,
+    y: f32,
+}
+
+#[export_module]
+pub mod test_module {
+    pub use super::Point;
+    #[rhai_fn(name = "foo", index_get, index_get)]
+    pub fn test_fn(input: Point) -> bool {
+        input.x > input.y
+    }
+}
+
+fn main() {
+    let n = Point {
+        x: 0.0,
+        y: 10.0,
+    };
+    if test_module::test_fn(n) {
+        println!("yes");
+    } else {
+        println!("no");
+    }
+}

--- a/codegen/ui_tests/rhai_fn_index_getter_multiple.stderr
+++ b/codegen/ui_tests/rhai_fn_index_getter_multiple.stderr
@@ -4,8 +4,8 @@ error: conflicting index_get
 12 |     #[rhai_fn(name = "foo", index_get, index_get)]
    |                                        ^^^^^^^^^
 
-error[E0433]: failed to resolve: use of undeclared type or module `test_module`
+error[E0433]: failed to resolve: use of undeclared crate or module `test_module`
   --> $DIR/rhai_fn_index_getter_multiple.rs:23:8
    |
 23 |     if test_module::test_fn(n) {
-   |        ^^^^^^^^^^^ use of undeclared type or module `test_module`
+   |        ^^^^^^^^^^^ use of undeclared crate or module `test_module`

--- a/codegen/ui_tests/rhai_fn_index_getter_multiple.stderr
+++ b/codegen/ui_tests/rhai_fn_index_getter_multiple.stderr
@@ -1,0 +1,11 @@
+error: conflicting index_get
+  --> $DIR/rhai_fn_index_getter_multiple.rs:12:40
+   |
+12 |     #[rhai_fn(name = "foo", index_get, index_get)]
+   |                                        ^^^^^^^^^
+
+error[E0433]: failed to resolve: use of undeclared type or module `test_module`
+  --> $DIR/rhai_fn_index_getter_multiple.rs:23:8
+   |
+23 |     if test_module::test_fn(n) {
+   |        ^^^^^^^^^^^ use of undeclared type or module `test_module`

--- a/codegen/ui_tests/rhai_fn_index_getter_return.rs
+++ b/codegen/ui_tests/rhai_fn_index_getter_return.rs
@@ -1,0 +1,28 @@
+use rhai::plugin::*;
+
+#[derive(Clone)]
+pub struct Point {
+    x: f32,
+    y: f32,
+}
+
+#[export_module]
+pub mod test_module {
+    pub use super::Point;
+    #[rhai_fn(index_get)]
+    pub fn test_fn(input: &mut Point, i: f32) {
+        input.x *= 2.0;
+    }
+}
+
+fn main() {
+    let mut n = Point {
+        x: 0.0,
+        y: 10.0,
+    };
+    if test_module::test_fn(&mut n, 5.0) {
+        println!("yes");
+    } else {
+        println!("no");
+    }
+}

--- a/codegen/ui_tests/rhai_fn_index_getter_return.stderr
+++ b/codegen/ui_tests/rhai_fn_index_getter_return.stderr
@@ -1,0 +1,11 @@
+error: index getter must return a value
+  --> $DIR/rhai_fn_index_getter_return.rs:13:9
+   |
+13 |     pub fn test_fn(input: &mut Point, i: f32) {
+   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+error[E0433]: failed to resolve: use of undeclared type or module `test_module`
+  --> $DIR/rhai_fn_index_getter_return.rs:23:8
+   |
+23 |     if test_module::test_fn(&mut n, 5.0) {
+   |        ^^^^^^^^^^^ use of undeclared type or module `test_module`

--- a/codegen/ui_tests/rhai_fn_index_getter_return.stderr
+++ b/codegen/ui_tests/rhai_fn_index_getter_return.stderr
@@ -4,8 +4,8 @@ error: index getter must return a value
 13 |     pub fn test_fn(input: &mut Point, i: f32) {
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-error[E0433]: failed to resolve: use of undeclared type or module `test_module`
+error[E0433]: failed to resolve: use of undeclared crate or module `test_module`
   --> $DIR/rhai_fn_index_getter_return.rs:23:8
    |
 23 |     if test_module::test_fn(&mut n, 5.0) {
-   |        ^^^^^^^^^^^ use of undeclared type or module `test_module`
+   |        ^^^^^^^^^^^ use of undeclared crate or module `test_module`

--- a/codegen/ui_tests/rhai_fn_index_getter_signature.rs
+++ b/codegen/ui_tests/rhai_fn_index_getter_signature.rs
@@ -1,0 +1,28 @@
+use rhai::plugin::*;
+
+#[derive(Clone)]
+pub struct Point {
+    x: f32,
+    y: f32,
+}
+
+#[export_module]
+pub mod test_module {
+    pub use super::Point;
+    #[rhai_fn(index_get)]
+    pub fn test_fn(input: Point) -> bool {
+        input.x > input.y
+    }
+}
+
+fn main() {
+    let n = Point {
+        x: 0.0,
+        y: 10.0,
+    };
+    if test_module::test_fn(n) {
+        println!("yes");
+    } else {
+        println!("no");
+    }
+}

--- a/codegen/ui_tests/rhai_fn_index_getter_signature.stderr
+++ b/codegen/ui_tests/rhai_fn_index_getter_signature.stderr
@@ -4,8 +4,8 @@ error: index getter requires exactly 2 arguments
 13 |     pub fn test_fn(input: Point) -> bool {
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-error[E0433]: failed to resolve: use of undeclared type or module `test_module`
+error[E0433]: failed to resolve: use of undeclared crate or module `test_module`
   --> $DIR/rhai_fn_index_getter_signature.rs:23:8
    |
 23 |     if test_module::test_fn(n) {
-   |        ^^^^^^^^^^^ use of undeclared type or module `test_module`
+   |        ^^^^^^^^^^^ use of undeclared crate or module `test_module`

--- a/codegen/ui_tests/rhai_fn_index_getter_signature.stderr
+++ b/codegen/ui_tests/rhai_fn_index_getter_signature.stderr
@@ -1,0 +1,11 @@
+error: index getter requires exactly 2 arguments
+  --> $DIR/rhai_fn_index_getter_signature.rs:13:9
+   |
+13 |     pub fn test_fn(input: Point) -> bool {
+   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+error[E0433]: failed to resolve: use of undeclared type or module `test_module`
+  --> $DIR/rhai_fn_index_getter_signature.rs:23:8
+   |
+23 |     if test_module::test_fn(n) {
+   |        ^^^^^^^^^^^ use of undeclared type or module `test_module`

--- a/codegen/ui_tests/rhai_fn_index_setter_multiple.rs
+++ b/codegen/ui_tests/rhai_fn_index_setter_multiple.rs
@@ -1,0 +1,28 @@
+use rhai::plugin::*;
+
+#[derive(Clone)]
+pub struct Point {
+    x: f32,
+    y: f32,
+}
+
+#[export_module]
+pub mod test_module {
+    pub use super::Point;
+    #[rhai_fn(name = "foo", index_set, index_set)]
+    pub fn test_fn(input: Point) -> bool {
+        input.x > input.y
+    }
+}
+
+fn main() {
+    let n = Point {
+        x: 0.0,
+        y: 10.0,
+    };
+    if test_module::test_fn(n) {
+        println!("yes");
+    } else {
+        println!("no");
+    }
+}

--- a/codegen/ui_tests/rhai_fn_index_setter_multiple.stderr
+++ b/codegen/ui_tests/rhai_fn_index_setter_multiple.stderr
@@ -1,0 +1,11 @@
+error: conflicting index_set
+  --> $DIR/rhai_fn_index_setter_multiple.rs:12:40
+   |
+12 |     #[rhai_fn(name = "foo", index_set, index_set)]
+   |                                        ^^^^^^^^^
+
+error[E0433]: failed to resolve: use of undeclared type or module `test_module`
+  --> $DIR/rhai_fn_index_setter_multiple.rs:23:8
+   |
+23 |     if test_module::test_fn(n) {
+   |        ^^^^^^^^^^^ use of undeclared type or module `test_module`

--- a/codegen/ui_tests/rhai_fn_index_setter_multiple.stderr
+++ b/codegen/ui_tests/rhai_fn_index_setter_multiple.stderr
@@ -4,8 +4,8 @@ error: conflicting index_set
 12 |     #[rhai_fn(name = "foo", index_set, index_set)]
    |                                        ^^^^^^^^^
 
-error[E0433]: failed to resolve: use of undeclared type or module `test_module`
+error[E0433]: failed to resolve: use of undeclared crate or module `test_module`
   --> $DIR/rhai_fn_index_setter_multiple.rs:23:8
    |
 23 |     if test_module::test_fn(n) {
-   |        ^^^^^^^^^^^ use of undeclared type or module `test_module`
+   |        ^^^^^^^^^^^ use of undeclared crate or module `test_module`

--- a/codegen/ui_tests/rhai_fn_rename_collision_oneattr_multiple.stderr
+++ b/codegen/ui_tests/rhai_fn_rename_collision_oneattr_multiple.stderr
@@ -1,14 +1,14 @@
-error: duplicate Rhai signature for 'get$bar'
-  --> $DIR/rhai_fn_rename_collision_oneattr_multiple.rs:17:15
-   |
-17 |     #[rhai_fn(get = "bar")]
-   |               ^^^^^^^^^^^
-
-error: duplicated function renamed 'get$bar'
+error: duplicate Rhai signature for 'foo'
   --> $DIR/rhai_fn_rename_collision_oneattr_multiple.rs:12:15
    |
 12 |     #[rhai_fn(name = "foo", get = "bar")]
    |               ^^^^^^^^^^^^^^^^^^^^^^^^^
+
+error: duplicated function 'foo'
+  --> $DIR/rhai_fn_rename_collision_oneattr_multiple.rs:18:12
+   |
+18 |     pub fn foo(input: Point) -> bool {
+   |            ^^^
 
 error[E0433]: failed to resolve: use of undeclared crate or module `test_module`
   --> $DIR/rhai_fn_rename_collision_oneattr_multiple.rs:25:8

--- a/codegen/ui_tests/rhai_fn_rename_dollar_sign.rs
+++ b/codegen/ui_tests/rhai_fn_rename_dollar_sign.rs
@@ -1,0 +1,28 @@
+use rhai::plugin::*;
+
+#[derive(Clone)]
+pub struct Point {
+    x: f32,
+    y: f32,
+}
+
+#[export_module]
+pub mod test_module {
+    pub use super::Point;
+    #[rhai_fn(name = "big$caching")]
+    pub fn test_fn(input: Point) -> bool {
+        input.x > input.y
+    }
+}
+
+fn main() {
+    let n = Point {
+        x: 0.0,
+        y: 10.0,
+    };
+    if test_module::test_fn(n) {
+        println!("yes");
+    } else {
+        println!("no");
+    }
+}

--- a/codegen/ui_tests/rhai_fn_rename_dollar_sign.stderr
+++ b/codegen/ui_tests/rhai_fn_rename_dollar_sign.stderr
@@ -1,0 +1,11 @@
+error: Rhai function names may not contain dollar sign
+  --> $DIR/rhai_fn_rename_dollar_sign.rs:12:22
+   |
+12 |     #[rhai_fn(name = "big$caching")]
+   |                      ^^^^^^^^^^^^^
+
+error[E0433]: failed to resolve: use of undeclared type or module `test_module`
+  --> $DIR/rhai_fn_rename_dollar_sign.rs:23:8
+   |
+23 |     if test_module::test_fn(n) {
+   |        ^^^^^^^^^^^ use of undeclared type or module `test_module`

--- a/codegen/ui_tests/rhai_fn_rename_dollar_sign.stderr
+++ b/codegen/ui_tests/rhai_fn_rename_dollar_sign.stderr
@@ -4,8 +4,8 @@ error: Rhai function names may not contain dollar sign
 12 |     #[rhai_fn(name = "big$caching")]
    |                      ^^^^^^^^^^^^^
 
-error[E0433]: failed to resolve: use of undeclared type or module `test_module`
+error[E0433]: failed to resolve: use of undeclared crate or module `test_module`
   --> $DIR/rhai_fn_rename_dollar_sign.rs:23:8
    |
 23 |     if test_module::test_fn(n) {
-   |        ^^^^^^^^^^^ use of undeclared type or module `test_module`
+   |        ^^^^^^^^^^^ use of undeclared crate or module `test_module`

--- a/codegen/ui_tests/rhai_fn_rename_to_index_getter.rs
+++ b/codegen/ui_tests/rhai_fn_rename_to_index_getter.rs
@@ -1,0 +1,28 @@
+use rhai::plugin::*;
+
+#[derive(Clone)]
+pub struct Point {
+    x: f32,
+    y: f32,
+}
+
+#[export_module]
+pub mod test_module {
+    pub use super::Point;
+    #[rhai_fn(name = "index$get$")]
+    pub fn test_fn(input: Point) -> bool {
+        input.x > input.y
+    }
+}
+
+fn main() {
+    let n = Point {
+        x: 0.0,
+        y: 10.0,
+    };
+    if test_module::test_fn(n) {
+        println!("yes");
+    } else {
+        println!("no");
+    }
+}

--- a/codegen/ui_tests/rhai_fn_rename_to_index_getter.stderr
+++ b/codegen/ui_tests/rhai_fn_rename_to_index_getter.stderr
@@ -1,0 +1,11 @@
+error: use attribute 'index_get' instead
+  --> $DIR/rhai_fn_rename_to_index_getter.rs:12:15
+   |
+12 |     #[rhai_fn(name = "index$get$")]
+   |               ^^^^^^^^^^^^^^^^^^^
+
+error[E0433]: failed to resolve: use of undeclared type or module `test_module`
+  --> $DIR/rhai_fn_rename_to_index_getter.rs:23:8
+   |
+23 |     if test_module::test_fn(n) {
+   |        ^^^^^^^^^^^ use of undeclared type or module `test_module`

--- a/codegen/ui_tests/rhai_fn_rename_to_index_getter.stderr
+++ b/codegen/ui_tests/rhai_fn_rename_to_index_getter.stderr
@@ -4,8 +4,8 @@ error: use attribute 'index_get' instead
 12 |     #[rhai_fn(name = "index$get$")]
    |               ^^^^^^^^^^^^^^^^^^^
 
-error[E0433]: failed to resolve: use of undeclared type or module `test_module`
+error[E0433]: failed to resolve: use of undeclared crate or module `test_module`
   --> $DIR/rhai_fn_rename_to_index_getter.rs:23:8
    |
 23 |     if test_module::test_fn(n) {
-   |        ^^^^^^^^^^^ use of undeclared type or module `test_module`
+   |        ^^^^^^^^^^^ use of undeclared crate or module `test_module`

--- a/codegen/ui_tests/rhai_fn_rename_to_index_setter.rs
+++ b/codegen/ui_tests/rhai_fn_rename_to_index_setter.rs
@@ -1,0 +1,28 @@
+use rhai::plugin::*;
+
+#[derive(Clone)]
+pub struct Point {
+    x: f32,
+    y: f32,
+}
+
+#[export_module]
+pub mod test_module {
+    pub use super::Point;
+    #[rhai_fn(name = "index$set$")]
+    pub fn test_fn(input: Point) -> bool {
+        input.x > input.y
+    }
+}
+
+fn main() {
+    let n = Point {
+        x: 0.0,
+        y: 10.0,
+    };
+    if test_module::test_fn(n) {
+        println!("yes");
+    } else {
+        println!("no");
+    }
+}

--- a/codegen/ui_tests/rhai_fn_rename_to_index_setter.stderr
+++ b/codegen/ui_tests/rhai_fn_rename_to_index_setter.stderr
@@ -4,8 +4,8 @@ error: use attribute 'index_set' instead
 12 |     #[rhai_fn(name = "index$set$")]
    |               ^^^^^^^^^^^^^^^^^^^
 
-error[E0433]: failed to resolve: use of undeclared type or module `test_module`
+error[E0433]: failed to resolve: use of undeclared crate or module `test_module`
   --> $DIR/rhai_fn_rename_to_index_setter.rs:23:8
    |
 23 |     if test_module::test_fn(n) {
-   |        ^^^^^^^^^^^ use of undeclared type or module `test_module`
+   |        ^^^^^^^^^^^ use of undeclared crate or module `test_module`

--- a/codegen/ui_tests/rhai_fn_rename_to_index_setter.stderr
+++ b/codegen/ui_tests/rhai_fn_rename_to_index_setter.stderr
@@ -1,0 +1,11 @@
+error: use attribute 'index_set' instead
+  --> $DIR/rhai_fn_rename_to_index_setter.rs:12:15
+   |
+12 |     #[rhai_fn(name = "index$set$")]
+   |               ^^^^^^^^^^^^^^^^^^^
+
+error[E0433]: failed to resolve: use of undeclared type or module `test_module`
+  --> $DIR/rhai_fn_rename_to_index_setter.rs:23:8
+   |
+23 |     if test_module::test_fn(n) {
+   |        ^^^^^^^^^^^ use of undeclared type or module `test_module`

--- a/codegen/ui_tests/rhai_fn_rename_to_prop_getter.rs
+++ b/codegen/ui_tests/rhai_fn_rename_to_prop_getter.rs
@@ -1,0 +1,28 @@
+use rhai::plugin::*;
+
+#[derive(Clone)]
+pub struct Point {
+    x: f32,
+    y: f32,
+}
+
+#[export_module]
+pub mod test_module {
+    pub use super::Point;
+    #[rhai_fn(name = "get$foo")]
+    pub fn test_fn(input: Point) -> bool {
+        input.x > input.y
+    }
+}
+
+fn main() {
+    let n = Point {
+        x: 0.0,
+        y: 10.0,
+    };
+    if test_module::test_fn(n) {
+        println!("yes");
+    } else {
+        println!("no");
+    }
+}

--- a/codegen/ui_tests/rhai_fn_rename_to_prop_getter.stderr
+++ b/codegen/ui_tests/rhai_fn_rename_to_prop_getter.stderr
@@ -1,0 +1,11 @@
+error: use attribute 'getter = "foo"' instead
+  --> $DIR/rhai_fn_rename_to_prop_getter.rs:12:15
+   |
+12 |     #[rhai_fn(name = "get$foo")]
+   |               ^^^^^^^^^^^^^^^^
+
+error[E0433]: failed to resolve: use of undeclared type or module `test_module`
+  --> $DIR/rhai_fn_rename_to_prop_getter.rs:23:8
+   |
+23 |     if test_module::test_fn(n) {
+   |        ^^^^^^^^^^^ use of undeclared type or module `test_module`

--- a/codegen/ui_tests/rhai_fn_rename_to_prop_getter.stderr
+++ b/codegen/ui_tests/rhai_fn_rename_to_prop_getter.stderr
@@ -4,8 +4,8 @@ error: use attribute 'getter = "foo"' instead
 12 |     #[rhai_fn(name = "get$foo")]
    |               ^^^^^^^^^^^^^^^^
 
-error[E0433]: failed to resolve: use of undeclared type or module `test_module`
+error[E0433]: failed to resolve: use of undeclared crate or module `test_module`
   --> $DIR/rhai_fn_rename_to_prop_getter.rs:23:8
    |
 23 |     if test_module::test_fn(n) {
-   |        ^^^^^^^^^^^ use of undeclared type or module `test_module`
+   |        ^^^^^^^^^^^ use of undeclared crate or module `test_module`

--- a/codegen/ui_tests/rhai_fn_rename_to_prop_setter.rs
+++ b/codegen/ui_tests/rhai_fn_rename_to_prop_setter.rs
@@ -1,0 +1,28 @@
+use rhai::plugin::*;
+
+#[derive(Clone)]
+pub struct Point {
+    x: f32,
+    y: f32,
+}
+
+#[export_module]
+pub mod test_module {
+    pub use super::Point;
+    #[rhai_fn(name = "get$foo")]
+    pub fn test_fn(input: Point) -> bool {
+        input.x > input.y
+    }
+}
+
+fn main() {
+    let n = Point {
+        x: 0.0,
+        y: 10.0,
+    };
+    if test_module::test_fn(n) {
+        println!("yes");
+    } else {
+        println!("no");
+    }
+}

--- a/codegen/ui_tests/rhai_fn_rename_to_prop_setter.stderr
+++ b/codegen/ui_tests/rhai_fn_rename_to_prop_setter.stderr
@@ -4,8 +4,8 @@ error: use attribute 'getter = "foo"' instead
 12 |     #[rhai_fn(name = "get$foo")]
    |               ^^^^^^^^^^^^^^^^
 
-error[E0433]: failed to resolve: use of undeclared type or module `test_module`
+error[E0433]: failed to resolve: use of undeclared crate or module `test_module`
   --> $DIR/rhai_fn_rename_to_prop_setter.rs:23:8
    |
 23 |     if test_module::test_fn(n) {
-   |        ^^^^^^^^^^^ use of undeclared type or module `test_module`
+   |        ^^^^^^^^^^^ use of undeclared crate or module `test_module`

--- a/codegen/ui_tests/rhai_fn_rename_to_prop_setter.stderr
+++ b/codegen/ui_tests/rhai_fn_rename_to_prop_setter.stderr
@@ -1,0 +1,11 @@
+error: use attribute 'getter = "foo"' instead
+  --> $DIR/rhai_fn_rename_to_prop_setter.rs:12:15
+   |
+12 |     #[rhai_fn(name = "get$foo")]
+   |               ^^^^^^^^^^^^^^^^
+
+error[E0433]: failed to resolve: use of undeclared type or module `test_module`
+  --> $DIR/rhai_fn_rename_to_prop_setter.rs:23:8
+   |
+23 |     if test_module::test_fn(n) {
+   |        ^^^^^^^^^^^ use of undeclared type or module `test_module`

--- a/codegen/ui_tests/rhai_fn_setter_index_signature.rs
+++ b/codegen/ui_tests/rhai_fn_setter_index_signature.rs
@@ -1,0 +1,28 @@
+use rhai::plugin::*;
+
+#[derive(Clone)]
+pub struct Point {
+    x: f32,
+    y: f32,
+}
+
+#[export_module]
+pub mod test_module {
+    pub use super::Point;
+    #[rhai_fn(index_set)]
+    pub fn test_fn(input: Point) -> bool {
+        input.x > input.y
+    }
+}
+
+fn main() {
+    let n = Point {
+        x: 0.0,
+        y: 10.0,
+    };
+    if test_module::test_fn(n) {
+        println!("yes");
+    } else {
+        println!("no");
+    }
+}

--- a/codegen/ui_tests/rhai_fn_setter_index_signature.stderr
+++ b/codegen/ui_tests/rhai_fn_setter_index_signature.stderr
@@ -4,8 +4,8 @@ error: index setter requires exactly 3 arguments
 13 |     pub fn test_fn(input: Point) -> bool {
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-error[E0433]: failed to resolve: use of undeclared type or module `test_module`
+error[E0433]: failed to resolve: use of undeclared crate or module `test_module`
   --> $DIR/rhai_fn_setter_index_signature.rs:23:8
    |
 23 |     if test_module::test_fn(n) {
-   |        ^^^^^^^^^^^ use of undeclared type or module `test_module`
+   |        ^^^^^^^^^^^ use of undeclared crate or module `test_module`

--- a/codegen/ui_tests/rhai_fn_setter_index_signature.stderr
+++ b/codegen/ui_tests/rhai_fn_setter_index_signature.stderr
@@ -1,0 +1,11 @@
+error: index setter requires exactly 3 arguments
+  --> $DIR/rhai_fn_setter_index_signature.rs:13:9
+   |
+13 |     pub fn test_fn(input: Point) -> bool {
+   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+error[E0433]: failed to resolve: use of undeclared type or module `test_module`
+  --> $DIR/rhai_fn_setter_index_signature.rs:23:8
+   |
+23 |     if test_module::test_fn(n) {
+   |        ^^^^^^^^^^^ use of undeclared type or module `test_module`

--- a/codegen/ui_tests/rhai_fn_setter_multiple.rs
+++ b/codegen/ui_tests/rhai_fn_setter_multiple.rs
@@ -1,0 +1,28 @@
+use rhai::plugin::*;
+
+#[derive(Clone)]
+pub struct Point {
+    x: f32,
+    y: f32,
+}
+
+#[export_module]
+pub mod test_module {
+    pub use super::Point;
+    #[rhai_fn(name = "foo", set = "foo", set = "bar")]
+    pub fn test_fn(input: Point) -> bool {
+        input.x > input.y
+    }
+}
+
+fn main() {
+    let n = Point {
+        x: 0.0,
+        y: 10.0,
+    };
+    if test_module::test_fn(n) {
+        println!("yes");
+    } else {
+        println!("no");
+    }
+}

--- a/codegen/ui_tests/rhai_fn_setter_multiple.stderr
+++ b/codegen/ui_tests/rhai_fn_setter_multiple.stderr
@@ -1,0 +1,11 @@
+error: conflicting setter
+  --> $DIR/rhai_fn_setter_multiple.rs:12:42
+   |
+12 |     #[rhai_fn(name = "foo", set = "foo", set = "bar")]
+   |                                          ^^^^^^^^^^^
+
+error[E0433]: failed to resolve: use of undeclared type or module `test_module`
+  --> $DIR/rhai_fn_setter_multiple.rs:23:8
+   |
+23 |     if test_module::test_fn(n) {
+   |        ^^^^^^^^^^^ use of undeclared type or module `test_module`

--- a/codegen/ui_tests/rhai_fn_setter_multiple.stderr
+++ b/codegen/ui_tests/rhai_fn_setter_multiple.stderr
@@ -4,8 +4,8 @@ error: conflicting setter
 12 |     #[rhai_fn(name = "foo", set = "foo", set = "bar")]
    |                                          ^^^^^^^^^^^
 
-error[E0433]: failed to resolve: use of undeclared type or module `test_module`
+error[E0433]: failed to resolve: use of undeclared crate or module `test_module`
   --> $DIR/rhai_fn_setter_multiple.rs:23:8
    |
 23 |     if test_module::test_fn(n) {
-   |        ^^^^^^^^^^^ use of undeclared type or module `test_module`
+   |        ^^^^^^^^^^^ use of undeclared crate or module `test_module`

--- a/codegen/ui_tests/rhai_fn_setter_return.rs
+++ b/codegen/ui_tests/rhai_fn_setter_return.rs
@@ -1,0 +1,29 @@
+use rhai::plugin::*;
+
+#[derive(Clone)]
+pub struct Point {
+    x: f32,
+    y: f32,
+}
+
+#[export_module]
+pub mod test_module {
+    pub use super::Point;
+    #[rhai_fn(set = "foo")]
+    pub fn test_fn(input: &mut Point, value: f32) -> bool {
+        let z = if value % 2 { input.x } else { input.y };
+        *input.x = z;
+    }
+}
+
+fn main() {
+    let mut n = Point {
+        x: 0.0,
+        y: 10.0,
+    };
+    if test_module::test_fn(&mut n, 5.0) {
+        println!("yes");
+    } else {
+        println!("no");
+    }
+}

--- a/codegen/ui_tests/rhai_fn_setter_return.stderr
+++ b/codegen/ui_tests/rhai_fn_setter_return.stderr
@@ -1,0 +1,11 @@
+error: property setter must return no value
+  --> $DIR/rhai_fn_setter_return.rs:13:9
+   |
+13 |     pub fn test_fn(input: &mut Point, value: f32) -> bool {
+   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+error[E0433]: failed to resolve: use of undeclared type or module `test_module`
+  --> $DIR/rhai_fn_setter_return.rs:24:8
+   |
+24 |     if test_module::test_fn(&mut n, 5.0) {
+   |        ^^^^^^^^^^^ use of undeclared type or module `test_module`

--- a/codegen/ui_tests/rhai_fn_setter_return.stderr
+++ b/codegen/ui_tests/rhai_fn_setter_return.stderr
@@ -4,8 +4,8 @@ error: property setter must return no value
 13 |     pub fn test_fn(input: &mut Point, value: f32) -> bool {
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-error[E0433]: failed to resolve: use of undeclared type or module `test_module`
+error[E0433]: failed to resolve: use of undeclared crate or module `test_module`
   --> $DIR/rhai_fn_setter_return.rs:24:8
    |
 24 |     if test_module::test_fn(&mut n, 5.0) {
-   |        ^^^^^^^^^^^ use of undeclared type or module `test_module`
+   |        ^^^^^^^^^^^ use of undeclared crate or module `test_module`

--- a/codegen/ui_tests/rhai_fn_setter_signature.rs
+++ b/codegen/ui_tests/rhai_fn_setter_signature.rs
@@ -1,0 +1,28 @@
+use rhai::plugin::*;
+
+#[derive(Clone)]
+pub struct Point {
+    x: f32,
+    y: f32,
+}
+
+#[export_module]
+pub mod test_module {
+    pub use super::Point;
+    #[rhai_fn(set = "foo")]
+    pub fn test_fn(input: Point) -> bool {
+        input.x > input.y
+    }
+}
+
+fn main() {
+    let n = Point {
+        x: 0.0,
+        y: 10.0,
+    };
+    if test_module::test_fn(n) {
+        println!("yes");
+    } else {
+        println!("no");
+    }
+}

--- a/codegen/ui_tests/rhai_fn_setter_signature.stderr
+++ b/codegen/ui_tests/rhai_fn_setter_signature.stderr
@@ -1,0 +1,11 @@
+error: property setter requires exactly 2 arguments
+  --> $DIR/rhai_fn_setter_signature.rs:13:9
+   |
+13 |     pub fn test_fn(input: Point) -> bool {
+   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+error[E0433]: failed to resolve: use of undeclared type or module `test_module`
+  --> $DIR/rhai_fn_setter_signature.rs:23:8
+   |
+23 |     if test_module::test_fn(n) {
+   |        ^^^^^^^^^^^ use of undeclared type or module `test_module`

--- a/codegen/ui_tests/rhai_fn_setter_signature.stderr
+++ b/codegen/ui_tests/rhai_fn_setter_signature.stderr
@@ -4,8 +4,8 @@ error: property setter requires exactly 2 arguments
 13 |     pub fn test_fn(input: Point) -> bool {
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-error[E0433]: failed to resolve: use of undeclared type or module `test_module`
+error[E0433]: failed to resolve: use of undeclared crate or module `test_module`
   --> $DIR/rhai_fn_setter_signature.rs:23:8
    |
 23 |     if test_module::test_fn(n) {
-   |        ^^^^^^^^^^^ use of undeclared type or module `test_module`
+   |        ^^^^^^^^^^^ use of undeclared crate or module `test_module`


### PR DESCRIPTION
Here it is: getters, setters, and indexers, fully implemented and checked.

In addition to enforcing at most one getter/setter/indexer per item, this also verifies that the user did not use a function signature that Rhai would never hash to (e.g. too many parameters) or that return values don't match (expected when absent, or ignored when present).

There are also a couple of miscellaneous checks that I put in as well, like disallowing "$" in renames.