### PR TITLE
New CI Job for Formatting

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -77,6 +77,29 @@ jobs:
       with:
         command: build
         args: --manifest-path=no_std/no_std_test/Cargo.toml ${{matrix.flags}}
+  rustfmt:
+    name: Check Formatting
+    runs-on: windows-latest
+    continue-on-error: true
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v2
+    - name: Setup Toolchain
+      uses: actions-rs/toolchain@v1
+      with:
+        toolchain: nightly
+        override: true
+        components: rustfmt, clippy
+    - name: Run Rustfmt
+      uses: actions-rs/cargo@v1
+      with:
+        command: fmt
+        args: --all -- --check
+    - name: Run Rustfmt
+      uses: actions-rs/cargo@v1
+      with:
+        command: clippy
+        args: --
   codegen_build:
     name: Codegen Build
     runs-on: ${{matrix.os}}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -95,11 +95,11 @@ jobs:
       with:
         command: fmt
         args: --all -- --check
-    - name: Run Rustfmt
+    - name: Run Clippy
       uses: actions-rs/cargo@v1
       with:
         command: clippy
-        args: --
+        args: --all -- -Aclippy::all -Dclippy::perf
   codegen_build:
     name: Codegen Build
     runs-on: ${{matrix.os}}

--- a/codegen/src/attrs.rs
+++ b/codegen/src/attrs.rs
@@ -32,7 +32,10 @@ pub struct ExportInfo {
 
 pub fn parse_attr_items(args: ParseStream) -> syn::Result<ExportInfo> {
     if args.is_empty() {
-        return Ok(ExportInfo { item_span: args.span(), items: Vec::new()});
+        return Ok(ExportInfo {
+            item_span: args.span(),
+            items: Vec::new(),
+        });
     }
     let arg_list = args
         .call(syn::punctuated::Punctuated::<syn::Expr, syn::Token![,]>::parse_separated_nonempty)?;
@@ -80,10 +83,17 @@ pub fn parse_punctuated_items(
                 .ok_or_else(|| syn::Error::new(attr_path.span(), "expecting attribute name"))?,
             x => return Err(syn::Error::new(x.span(), "expecting identifier")),
         };
-        attrs.push(AttrItem { key, value, span: arg_span });
+        attrs.push(AttrItem {
+            key,
+            value,
+            span: arg_span,
+        });
     }
 
-    Ok(ExportInfo { item_span: list_span, items: attrs })
+    Ok(ExportInfo {
+        item_span: list_span,
+        items: attrs,
+    })
 }
 
 pub(crate) fn outer_item_attributes<T: ExportedParams>(

--- a/codegen/tests/test_nested.rs
+++ b/codegen/tests/test_nested.rs
@@ -187,7 +187,6 @@ fn export_nested_by_prefix_test() -> Result<(), Box<EvalAltResult>> {
             if s == "math::bar_fourth_adders::add_int (i64, i64)"
             && p == rhai::Position::new(3, 42)));
 
-
     assert!(matches!(*engine.eval::<FLOAT>(
         r#"import "Math::Advanced" as math;
        let ex = 41.0;

--- a/src/engine.rs
+++ b/src/engine.rs
@@ -1168,7 +1168,7 @@ impl Engine {
                         .take_immutable_string()
                         .map_err(|_| EvalAltResult::ErrorStringIndexExpr(idx_pos))?;
 
-                    map.entry(index).or_insert(Default::default()).into()
+                    map.entry(index).or_insert_with(Default::default).into()
                 } else {
                     let index = idx
                         .read_lock::<ImmutableString>()
@@ -2014,6 +2014,6 @@ impl Engine {
         self.type_names
             .as_ref()
             .and_then(|t| t.get(name).map(String::as_str))
-            .unwrap_or(map_std_type_name(name))
+            .unwrap_or_else(|| map_std_type_name(name))
     }
 }

--- a/src/packages/map_basic.rs
+++ b/src/packages/map_basic.rs
@@ -46,9 +46,7 @@ mod map_functions {
     }
     pub fn fill_with(map1: &mut Map, map2: Map) {
         map2.into_iter().for_each(|(key, value)| {
-            if !map1.contains_key(&key) {
-                map1.insert(key, value);
-            }
+            map1.entry(key).or_insert(value);
         });
     }
 

--- a/src/packages/mod.rs
+++ b/src/packages/mod.rs
@@ -1,5 +1,8 @@
 //! Module containing all built-in _packages_ available to Rhai, plus facilities to define custom packages.
 
+// Hide clippy errors from exported modules
+#![allow(clippy::redundant_clone)]
+
 use crate::fn_native::{CallableFunction, IteratorFn, Shared};
 use crate::module::Module;
 use crate::utils::StaticVec;

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -3479,7 +3479,7 @@ pub fn map_dynamic_to_expr(value: Dynamic, pos: Position) -> Option<Expr> {
         Union::Unit(_) => Some(Expr::Unit(pos)),
         Union::Int(value) => Some(Expr::IntegerConstant(Box::new((value, pos)))),
         Union::Char(value) => Some(Expr::CharConstant(Box::new((value, pos)))),
-        Union::Str(value) => Some(Expr::StringConstant(Box::new((value.clone(), pos)))),
+        Union::Str(value) => Some(Expr::StringConstant(Box::new((value, pos)))),
         Union::Bool(true) => Some(Expr::True(pos)),
         Union::Bool(false) => Some(Expr::False(pos)),
         #[cfg(not(feature = "no_index"))]


### PR DESCRIPTION
It makes `rustfmt` mandatory, and `clippy` optional. I plan to add some clippy deny lints as a separate PR.

EDIT: since clippy didn't behave the way I expected, this denies `clippy::perf` -- code which has a perf impact -- and allows everything else.