### PR TITLE
Remove redundant clones in codegen

### DIFF
--- a/codegen/src/function.rs
+++ b/codegen/src/function.rs
@@ -672,7 +672,7 @@ impl ExportedFn {
                             is_string = false;
                             is_ref = false;
                             quote_spanned!(arg_type.span()=>
-                                           mem::take(args[#i]).clone().cast::<#arg_type>())
+                                           mem::take(args[#i]).cast::<#arg_type>())
                         }
                     };
 

--- a/codegen/src/test/function.rs
+++ b/codegen/src/test/function.rs
@@ -323,7 +323,7 @@ mod generate_tests {
                     ) -> Result<Dynamic, Box<EvalAltResult>> {
                         debug_assert_eq!(args.len(), 1usize,
                                     "wrong arg count: {} != {}", args.len(), 1usize);
-                        let arg0 = mem::take(args[0usize]).clone().cast::<usize>();
+                        let arg0 = mem::take(args[0usize]).cast::<usize>();
                         Ok(Dynamic::from(do_something(arg0)))
                     }
 
@@ -364,7 +364,7 @@ mod generate_tests {
                 ) -> Result<Dynamic, Box<EvalAltResult>> {
                     debug_assert_eq!(args.len(), 1usize,
                                 "wrong arg count: {} != {}", args.len(), 1usize);
-                    let arg0 = mem::take(args[0usize]).clone().cast::<usize>();
+                    let arg0 = mem::take(args[0usize]).cast::<usize>();
                     Ok(Dynamic::from(do_something(arg0)))
                 }
 
@@ -398,8 +398,8 @@ mod generate_tests {
                     ) -> Result<Dynamic, Box<EvalAltResult>> {
                         debug_assert_eq!(args.len(), 2usize,
                                     "wrong arg count: {} != {}", args.len(), 2usize);
-                        let arg0 = mem::take(args[0usize]).clone().cast::<usize>();
-                        let arg1 = mem::take(args[1usize]).clone().cast::<usize>();
+                        let arg0 = mem::take(args[0usize]).cast::<usize>();
+                        let arg1 = mem::take(args[1usize]).cast::<usize>();
                         Ok(Dynamic::from(add_together(arg0, arg1)))
                     }
 
@@ -445,7 +445,7 @@ mod generate_tests {
                     ) -> Result<Dynamic, Box<EvalAltResult>> {
                         debug_assert_eq!(args.len(), 2usize,
                                     "wrong arg count: {} != {}", args.len(), 2usize);
-                        let arg1 = mem::take(args[1usize]).clone().cast::<usize>();
+                        let arg1 = mem::take(args[1usize]).cast::<usize>();
                         let arg0: &mut _ = &mut args[0usize].write_lock::<usize>().unwrap();
                         Ok(Dynamic::from(increment(arg0, arg1)))
                     }

--- a/codegen/src/test/module.rs
+++ b/codegen/src/test/module.rs
@@ -369,7 +369,7 @@ mod generate_tests {
                     ) -> Result<Dynamic, Box<EvalAltResult>> {
                         debug_assert_eq!(args.len(), 1usize,
                                             "wrong arg count: {} != {}", args.len(), 1usize);
-                        let arg0 = mem::take(args[0usize]).clone().cast::<INT>();
+                        let arg0 = mem::take(args[0usize]).cast::<INT>();
                         Ok(Dynamic::from(add_one_to(arg0)))
                     }
 
@@ -446,7 +446,7 @@ mod generate_tests {
                     ) -> Result<Dynamic, Box<EvalAltResult>> {
                         debug_assert_eq!(args.len(), 1usize,
                                             "wrong arg count: {} != {}", args.len(), 1usize);
-                        let arg0 = mem::take(args[0usize]).clone().cast::<INT>();
+                        let arg0 = mem::take(args[0usize]).cast::<INT>();
                         Ok(Dynamic::from(add_one_to(arg0)))
                     }
 
@@ -474,8 +474,8 @@ mod generate_tests {
                     ) -> Result<Dynamic, Box<EvalAltResult>> {
                         debug_assert_eq!(args.len(), 2usize,
                                             "wrong arg count: {} != {}", args.len(), 2usize);
-                        let arg0 = mem::take(args[0usize]).clone().cast::<INT>();
-                        let arg1 = mem::take(args[1usize]).clone().cast::<INT>();
+                        let arg0 = mem::take(args[0usize]).cast::<INT>();
+                        let arg1 = mem::take(args[1usize]).cast::<INT>();
                         Ok(Dynamic::from(add_n_to(arg0, arg1)))
                     }
 
@@ -540,8 +540,8 @@ mod generate_tests {
                     ) -> Result<Dynamic, Box<EvalAltResult>> {
                         debug_assert_eq!(args.len(), 2usize,
                                             "wrong arg count: {} != {}", args.len(), 2usize);
-                        let arg0 = mem::take(args[0usize]).clone().cast::<INT>();
-                        let arg1 = mem::take(args[1usize]).clone().cast::<INT>();
+                        let arg0 = mem::take(args[0usize]).cast::<INT>();
+                        let arg1 = mem::take(args[1usize]).cast::<INT>();
                         Ok(Dynamic::from(add_together(arg0, arg1)))
                     }
 
@@ -613,8 +613,8 @@ mod generate_tests {
                     ) -> Result<Dynamic, Box<EvalAltResult>> {
                         debug_assert_eq!(args.len(), 2usize,
                                             "wrong arg count: {} != {}", args.len(), 2usize);
-                        let arg0 = mem::take(args[0usize]).clone().cast::<INT>();
-                        let arg1 = mem::take(args[1usize]).clone().cast::<INT>();
+                        let arg0 = mem::take(args[0usize]).cast::<INT>();
+                        let arg1 = mem::take(args[1usize]).cast::<INT>();
                         Ok(Dynamic::from(add_together(arg0, arg1)))
                     }
 
@@ -1447,7 +1447,7 @@ mod generate_tests {
                     ) -> Result<Dynamic, Box<EvalAltResult>> {
                         debug_assert_eq!(args.len(), 2usize,
                                             "wrong arg count: {} != {}", args.len(), 2usize);
-                        let arg1 = mem::take(args[1usize]).clone().cast::<u64>();
+                        let arg1 = mem::take(args[1usize]).cast::<u64>();
                         let arg0: &mut _ = &mut args[0usize].write_lock::<u64>().unwrap();
                         Ok(Dynamic::from(int_foo(arg0, arg1)))
                     }
@@ -1518,7 +1518,7 @@ mod generate_tests {
                     ) -> Result<Dynamic, Box<EvalAltResult>> {
                         debug_assert_eq!(args.len(), 2usize,
                                             "wrong arg count: {} != {}", args.len(), 2usize);
-                        let arg1 = mem::take(args[1usize]).clone().cast::<u64>();
+                        let arg1 = mem::take(args[1usize]).cast::<u64>();
                         let arg0: &mut _ = &mut args[0usize].write_lock::<u64>().unwrap();
                         Ok(Dynamic::from(int_foo(arg0, arg1)))
                     }
@@ -1585,7 +1585,7 @@ mod generate_tests {
                     ) -> Result<Dynamic, Box<EvalAltResult>> {
                         debug_assert_eq!(args.len(), 2usize,
                                             "wrong arg count: {} != {}", args.len(), 2usize);
-                        let arg1 = mem::take(args[1usize]).clone().cast::<u64>();
+                        let arg1 = mem::take(args[1usize]).cast::<u64>();
                         let arg0: &mut _ = &mut args[0usize].write_lock::<MyCollection>().unwrap();
                         Ok(Dynamic::from(get_by_index(arg0, arg1)))
                     }
@@ -1657,7 +1657,7 @@ mod generate_tests {
                     ) -> Result<Dynamic, Box<EvalAltResult>> {
                         debug_assert_eq!(args.len(), 2usize,
                                             "wrong arg count: {} != {}", args.len(), 2usize);
-                        let arg1 = mem::take(args[1usize]).clone().cast::<u64>();
+                        let arg1 = mem::take(args[1usize]).cast::<u64>();
                         let arg0: &mut _ = &mut args[0usize].write_lock::<MyCollection>().unwrap();
                         Ok(Dynamic::from(get_by_index(arg0, arg1)))
                     }
@@ -1726,8 +1726,8 @@ mod generate_tests {
                     ) -> Result<Dynamic, Box<EvalAltResult>> {
                         debug_assert_eq!(args.len(), 3usize,
                                             "wrong arg count: {} != {}", args.len(), 3usize);
-                        let arg1 = mem::take(args[1usize]).clone().cast::<u64>();
-                        let arg2 = mem::take(args[2usize]).clone().cast::<FLOAT>();
+                        let arg1 = mem::take(args[1usize]).cast::<u64>();
+                        let arg2 = mem::take(args[2usize]).cast::<FLOAT>();
                         let arg0: &mut _ = &mut args[0usize].write_lock::<MyCollection>().unwrap();
                         Ok(Dynamic::from(set_by_index(arg0, arg1, arg2)))
                     }
@@ -1802,8 +1802,8 @@ mod generate_tests {
                     ) -> Result<Dynamic, Box<EvalAltResult>> {
                         debug_assert_eq!(args.len(), 3usize,
                                             "wrong arg count: {} != {}", args.len(), 3usize);
-                        let arg1 = mem::take(args[1usize]).clone().cast::<u64>();
-                        let arg2 = mem::take(args[2usize]).clone().cast::<FLOAT>();
+                        let arg1 = mem::take(args[1usize]).cast::<u64>();
+                        let arg2 = mem::take(args[2usize]).cast::<FLOAT>();
                         let arg0: &mut _ = &mut args[0usize].write_lock::<MyCollection>().unwrap();
                         Ok(Dynamic::from(set_by_index(arg0, arg1, arg2)))
                     }

--- a/src/packages/mod.rs
+++ b/src/packages/mod.rs
@@ -1,8 +1,5 @@
 //! Module containing all built-in _packages_ available to Rhai, plus facilities to define custom packages.
 
-// Hide clippy errors from exported modules
-#![allow(clippy::redundant_clone)]
-
 use crate::fn_native::{CallableFunction, IteratorFn, Shared};
 use crate::module::Module;
 use crate::utils::StaticVec;


### PR DESCRIPTION
Also un-suppresses the lint that warned me.